### PR TITLE
fix post-cloud redirect

### DIFF
--- a/CherryPy.conf
+++ b/CherryPy.conf
@@ -74,8 +74,8 @@ tools.sessions.on: True
 tools.sessions.table_name = "cherrypy.sessions"
 tools.sessions.timeout: 30
 tools.sessions.path: '/'
-#tools.sessions.domain: '.gutenberg.org'
-tools.sessions.domain: 'localhost'
+tools.sessions.domain: '.gutenberg.org'
+#tools.sessions.domain: 'localhost'
 
 tools.expires.on: True
 tools.expires.secs: 0


### PR DESCRIPTION
noticed that after cloud storage, redirects were always http.

Now the redirects respect the host_https setting.

Note that clients that do not support https cannot use cloud storage.