### PR TITLE
Fix to logic error for wikipedia entries for authors with only one work.

### DIFF
--- a/SearchPage.py
+++ b/SearchPage.py
@@ -237,7 +237,7 @@ class AuthorPage (SearchPage):
 
     def fixup (self, os):
 
-        if (os.start_index == 1 and len (os.entries) > 1):
+        if (os.start_index == 1 and len (os.entries) > 0):
 
             # browse-by-author page for maintainers
             if 'is-catalog-maintainer' in cherrypy.request.cookie:


### PR DESCRIPTION
(Re-applying, since this wasn't checked in the first time).

This shows Wikipedia entries when an author only has a single eBook in the catalog. The previous logic would hide Wikipedia entries, even if they existed, unless the author had > 1 eBooks.