### PR TITLE
Update CherryPy.conf

### DIFF
--- a/CherryPy.conf
+++ b/CherryPy.conf
@@ -10,7 +10,8 @@ server.socket_host: '::'
 server.socket_port: 8000
 server.socket_queue_size: 10
 server.thread_pool: 20
-server.thread_pool_max: 20
+# gbn 20190630: -1 (infinite) is the default per _cpserver.py
+# server.thread_pool_max: -1 # This was set to 20, which is an unnecessary limit
 
 # change host and postgres params in .autocat3 or /etc/autocat3.conf files
 pghost:     'localhost'


### PR DESCRIPTION
make thread_pool_max the default (-1  == infinite) rather than setting to 20, which seems an unnecessary limt.