### PR TITLE
stop using builtins as global

### DIFF
--- a/BaseSearcher.py
+++ b/BaseSearcher.py
@@ -33,6 +33,9 @@ from libgutenberg import DublinCore
 from libgutenberg import GutenbergDatabaseDublinCore
 from libgutenberg import GutenbergGlobals as gg
 
+from i18n_tool import ugettext as _
+from i18n_tool import ungettext as __
+
 import DublinCoreI18n
 from SupportedLocales import FB_LANGS, TWITTER_LANGS, GOOGLE_LANGS, PAYPAL_LANGS, FLATTR_LANGS
 

--- a/BibrecPage.py
+++ b/BibrecPage.py
@@ -17,6 +17,8 @@ from __future__ import unicode_literals
 import cherrypy
 
 from libgutenberg import GutenbergGlobals as gg
+from i18n_tool import ugettext as _
+from i18n_tool import ungettext as __
 
 import BaseSearcher
 import Page

--- a/CherryPyApp.py
+++ b/CherryPyApp.py
@@ -24,16 +24,8 @@ import traceback
 
 import cherrypy
 from cherrypy.process import plugins
-import six
-from six.moves import builtins
 
 from libgutenberg import GutenbergDatabase
-
-import i18n_tool
-# Make translator functions available everywhere. Do this early, at
-# least before Genshi starts loading templates.
-builtins._ = i18n_tool.ugettext
-builtins.__ = i18n_tool.ungettext
 
 # this import causes ConnectionPool.ConnectionPool to become the cherrypy connection pool
 import ConnectionPool

--- a/CloudStorage.py
+++ b/CloudStorage.py
@@ -28,6 +28,7 @@ import requests_oauthlib
 from requests import RequestException
 from oauthlib.oauth2.rfc6749.errors import OAuth2Error
 
+from i18n_tool import ugettext as _
 import BaseSearcher
 
 # pylint: disable=R0921

--- a/DublinCoreI18n.py
+++ b/DublinCoreI18n.py
@@ -17,7 +17,7 @@ from __future__ import unicode_literals
 
 import cherrypy
 import babel
-
+from i18n_tool import ugettext as _
 
 class DublinCoreI18nMixin (object):
     """ Translator Mixin for GutenbergDatabaseDublinCore class. """

--- a/Formatters.py
+++ b/Formatters.py
@@ -23,6 +23,7 @@ import genshi.filters
 
 import cherrypy
 
+from i18n_tool import ugettext as _
 import HTMLFormatter
 import OPDSFormatter
 import JSONFormatter

--- a/HTMLFormatter.py
+++ b/HTMLFormatter.py
@@ -26,6 +26,7 @@ from libgutenberg.MediaTypes import mediatypes as mt
 
 import BaseSearcher
 import BaseFormatter
+from i18n_tool import ugettext as _
 
 # filetypes ignored on desktop site
 NO_DESKTOP_FILETYPES = 'plucker qioo rdf rst rst.gen rst.master tei cover.medium cover.small'.split ()

--- a/Page.py
+++ b/Page.py
@@ -23,6 +23,7 @@ from libgutenberg.GutenbergDatabase import DatabaseError
 
 import BaseSearcher
 import Formatters
+from i18n_tool import ugettext as _
 
 class Page (object):
     """ Base for all pages. """

--- a/SearchPage.py
+++ b/SearchPage.py
@@ -21,6 +21,8 @@ from libgutenberg.DublinCore import DublinCore
 
 import BaseSearcher
 from Page import SearchPage
+from i18n_tool import ugettext as _
+from i18n_tool import ungettext as __
 
 
 class BookSearchPage (SearchPage):

--- a/StartPage.py
+++ b/StartPage.py
@@ -16,6 +16,7 @@ from __future__ import unicode_literals
 
 import BaseSearcher
 import Page
+from i18n_tool import ugettext as _
 
 class Start (Page.Page):
     """ The start page. """

--- a/templates/results.opds
+++ b/templates/results.opds
@@ -14,7 +14,7 @@ which contains *all* Project Gutenberg metadata in one RDF/XML file.
 <?python
   import re
   from libgutenberg import GutenbergGlobals as gg
-
+  from i18n_tool import ugettext as _
   if os.format == 'stanza':
      os.type_opds = "application/atom+xml"
      opds_relations = {


### PR DESCRIPTION
the old EbookMaker installed a null function into `builtins._` . It's not clear if or how the two installations  of `builtins._` affect each other. In any case, it seems dangerous and unnecessary.

Its unlikely that this is causing any problems, but easier to be sure.