### PR TITLE
add thread report

### DIFF
--- a/diagnostics.py
+++ b/diagnostics.py
@@ -13,9 +13,14 @@ import resource
 import sys
 from collections import Mapping, Container
 from sys import getsizeof
+import threading
+
 import cherrypy
 from cherrypy.lib.sessions import RamSession
 from Page import Page
+
+def thread_info():
+    return [t.name for t in threading.enumerate()]
 
 def deep_getsizeof(o, ids):
     """Find the memory footprint of a Python object
@@ -66,5 +71,6 @@ class DiagnosticsPage (Page):
         stats['allocated_blocks'] = sys.getallocatedblocks()
         stats['rusage_self'] = resource.getrusage(resource.RUSAGE_SELF)
         stats['rusage_children'] = resource.getrusage(resource.RUSAGE_CHILDREN)
+        stats['thread_info'] = thread_info()
         return stats
 


### PR DESCRIPTION
Adds a list of alive threads to diagnostics report.
I have a hypothesis about our session cleanup problem.
When new sessions are created, there is a check that the cleanup thread is not null, but not that it is alive. if I am correct, the cleanup thread will disappear from the list of live threads. 

If true, we can patch CherryPy to fix this.