### PR TITLE
mkdir -p

### DIFF
--- a/autocat3.service
+++ b/autocat3.service
@@ -7,7 +7,7 @@ User=autocat
 Type=simple
 RuntimeDirectory=autocat
 WorkingDirectory=/var/lib/autocat/autocat3
-ExecStartPre=-/usr/bin/mkdir /var/run/autocat
+ExecStartPre=-/usr/bin/mkdir -p /var/run/autocat
 ExecStart=/var/lib/autocat/.local/bin/pipenv run python CherryPyApp.py
 
 [Install]


### PR DESCRIPTION
to avoid warning when directory is already there

```
autocat3.service - autocat3 Service
   Loaded: loaded (/var/lib/autocat/autocat3/autocat3.service; enabled; vendor preset: disabled)
   Active: active (running) since Tue 2019-08-20 10:14:37 EDT; 7s ago
  Process: 21557 ExecStartPre=/usr/bin/mkdir /var/run/autocat (code=exited, status=1/FAILURE)
 Main PID: 21559 (python)
   CGroup: /system.slice/autocat3.service
           └─21559 /var/lib/autocat/.local/share/virtualenvs/autocat3-mGIyuTut/bin/python CherryPyApp.py
```

> gbnewby 10:46 AM
> @gluejar the service should use “mkdir -p” rather than “mkdir” - that will quell the status=1/FAILURE. This is in autocat3/autocat3.service