### PR TITLE
Update autocat3.service

### DIFF
--- a/autocat3.service
+++ b/autocat3.service
@@ -9,6 +9,8 @@ RuntimeDirectory=autocat
 WorkingDirectory=/var/lib/autocat/autocat3
 ExecStartPre=-/usr/bin/mkdir -p /var/run/autocat
 ExecStart=/usr/local/bin/pipenv run python CherryPyApp.py
+LimitNOFILE=infinity
+
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This allows the system file limit to apply to the service, rather than the per-user or shell limit.

It should fix occasional "too many open files" errors.