### PR TITLE
switch to using updated javascript

### DIFF
--- a/templates/error.html
+++ b/templates/error.html
@@ -28,7 +28,7 @@
         var dialog_title    = "";
         var dialog_message  = "";
         //]]></script>
-    <script type="text/javascript" src="/js/pg-desktop-one.js" />
+    <script type="text/javascript" src="/js/pg-two.js" />
     <link rel="shortcut icon"             href="/gutenberg/favicon.ico" />
     <meta http-equiv="Content-Type"       content="text/html; charset=UTF-8" />
     <meta http-equiv="Content-Style-Type" content="text/css" />

--- a/templates/site-layout.html
+++ b/templates/site-layout.html
@@ -29,7 +29,7 @@
       var dialog_message  = "${os.user_dialog[0]}";
     //]]></script>
 
-    <script src="/js/pg-desktop-one.js" />
+    <script src="/js/pg-two.js" />
 
     <link rel="shortcut icon"             href="/gutenberg/favicon.ico" />
     <link rel="canonical"                 href="${os.canonical_url}" />


### PR DESCRIPTION
Depends on adding the new javascript to the static js directory https://github.com/gbnewby/gutenbergsite/pull/14

This should enable autocomplete on the menu search box