### PR TITLE
show zips, hide non-generated, update microdata

### DIFF
--- a/DublinCoreI18n.py
+++ b/DublinCoreI18n.py
@@ -66,7 +66,5 @@ class DublinCoreI18nMixin (object):
                 lang.language = cherrypy.response.i18n.locale.languages[lang.id].capitalize ()
         for file_ in self.files:
             file_.hr_filetype = _(file_.hr_filetype)
-        for file_ in self.generated_files:
-            file_.hr_filetype = _(file_.hr_filetype)
 
         self.translated = True

--- a/HTMLFormatter.py
+++ b/HTMLFormatter.py
@@ -56,12 +56,6 @@ class XMLishFormatter (BaseFormatter.BaseFormatter):
 
         super (XMLishFormatter, self).fix_dc (dc, os)
 
-        # generated_files always [] AFAICT -esh
-        for file_ in dc.generated_files:
-            file_.help_topic = file_.hr_filetype
-            file_.compression = 'none'
-            file_.encoding  = None
-
         dedupable = {}
         for file_ in dc.files:
             if file_.filetype and file_.filetype.endswith('images'):
@@ -77,7 +71,7 @@ class XMLishFormatter (BaseFormatter.BaseFormatter):
                 if ft + '.images' in dedupable and ft + '.noimages' in dedupable:
                     dc.files.remove(dedupable[ft + '.images'])
                 
-        for file_ in dc.files + dc.generated_files:
+        for file_ in dc.files:
             type_ = six.text_type (file_.mediatypes[0])
             m = type_.partition (';')[0]
             if m in CLOUD_TYPES and has_std_path (file_):
@@ -153,7 +147,7 @@ class HTMLFormatter (XMLishFormatter):
         # hide all txt files but the first one
         txtcount = showncount = htmlcount = 0
 
-        for file_ in dc.files + dc.generated_files:
+        for file_ in dc.files:
             filetype = file_.filetype or ''
             file_.hidden = False
 
@@ -179,5 +173,5 @@ class HTMLFormatter (XMLishFormatter):
 
         # if we happened to hide everything, show all files
         if showncount == 0:
-            for file_ in dc.files + dc.generated_files:
+            for file_ in dc.files:
                 file_.hidden = False

--- a/HTMLFormatter.py
+++ b/HTMLFormatter.py
@@ -153,7 +153,10 @@ class HTMLFormatter (XMLishFormatter):
 
             if filetype in NO_DESKTOP_FILETYPES:
                 file_.hidden = True
-            if file_.compression != 'none':
+            if file_.compression == 'zip' and file_.archive_path.startswith('cache/epub'):
+                file_.hr_filetype = 'Download HTML5 zip archive'
+                file_.mediatypes.append('application/zip')
+            elif file_.compression != 'none':
                 file_.hidden = True
             if filetype.startswith ('txt'):
                 if txtcount > 0:

--- a/HTMLFormatter.py
+++ b/HTMLFormatter.py
@@ -38,7 +38,6 @@ HANDOVER_TYPES = (mt.epub, mt.mobi, mt.pdf)
 # self-contained files we can send to dropbox
 CLOUD_TYPES = (mt.epub, mt.mobi, mt.pdf)
 STD_PDF_MATCH = re.compile (r'files/\d+/\d+-pdf.pdf$')
-NEW_FILETYPES = {'kf8.images', 'epub3.images'}
 
 class XMLishFormatter (BaseFormatter.BaseFormatter):
     """ Produce XMLish output. """
@@ -153,7 +152,6 @@ class HTMLFormatter (XMLishFormatter):
 
         # hide all txt files but the first one
         txtcount = showncount = htmlcount = 0
-        show_new_ft = cherrypy.config['version'] >= 12
 
         for file_ in dc.files + dc.generated_files:
             filetype = file_.filetype or ''
@@ -172,12 +170,10 @@ class HTMLFormatter (XMLishFormatter):
             if file_.encoding:
                 file_.hr_filetype += ' ' + file_.encoding.upper ()
             if filetype.startswith ('html') and file_.compression == 'none':
-                if htmlcount > 0 and not show_new_ft:
+                if htmlcount > 0:
                     file_.hidden = True
                 file_.hr_filetype = 'Read this book online: {}'.format (file_.hr_filetype)
                 htmlcount += 1
-            if filetype in NEW_FILETYPES and not show_new_ft:
-                file_.hidden = True
             if not file_.hidden:
                 showncount += 1
 

--- a/HTMLFormatter.py
+++ b/HTMLFormatter.py
@@ -154,7 +154,7 @@ class HTMLFormatter (XMLishFormatter):
             if filetype in NO_DESKTOP_FILETYPES:
                 file_.hidden = True
             if file_.compression == 'zip' and file_.archive_path.startswith('cache/epub'):
-                file_.hr_filetype = 'Download HTML5 zip archive'
+                file_.hr_filetype = 'Download HTML (zip)'
                 file_.mediatypes.append('application/zip')
             elif file_.compression != 'none':
                 file_.hidden = True
@@ -169,7 +169,7 @@ class HTMLFormatter (XMLishFormatter):
             if filetype.startswith ('html') and file_.compression == 'none':
                 if htmlcount > 0:
                     file_.hidden = True
-                file_.hr_filetype = 'Read this book online: {}'.format (file_.hr_filetype)
+                file_.hr_filetype = 'Read online (web)'
                 htmlcount += 1
             if not file_.hidden:
                 showncount += 1

--- a/OPDSFormatter.py
+++ b/OPDSFormatter.py
@@ -126,7 +126,7 @@ class OPDSFormatter (BaseFormatter.BaseFormatter):
 
         dc.authors.sort (key = key_role)
 
-        for file_ in dc.files + dc.generated_files:
+        for file_ in dc.files:
             if len (file_.mediatypes) == 1:
                 type_ = six.text_type (file_.mediatypes[0])
                 filetype = file_.filetype or ''

--- a/templates/bibrec.html
+++ b/templates/bibrec.html
@@ -162,7 +162,7 @@ Gutenberg metadata much faster than by scraping.
                   <td property="dcterms:format" content="${file_.mediatypes[-1]}" datatype="dcterms:IMT"
                   class="unpadded icon_save"
                   ><a href="/${file_.filename}" type="${file_.mediatypes[-1]}" class="link"
-                      title="${'Read online' if file_.filetype.startswith('html') else 'Download'}">${file_.hr_filetype}</a></td>
+                      title="${'Read online' if file_.filetype and file_.filetype.startswith('html') else 'Download'}">${file_.hr_filetype}</a></td>
                   <td class="noscreen">${file_.url}</td>
                   <td  class="right"
                    property="dcterms:extent" content="${file_.extent}">${file_.hr_extent}</td>

--- a/templates/bibrec.html
+++ b/templates/bibrec.html
@@ -70,10 +70,9 @@ Gutenberg metadata much faster than by scraping.
     <div class="page_content" id="content" itemscope="itemscope" itemtype="http://schema.org/Book" i18n:comment="On the 'bibrec' page.">
 
       <div class="breadcrumbs noprint">
-	<ul>
+	<ul itemscope="itemscope" itemtype="https://schema.org/BreadcrumbList">
 	  <py:for each="n, bc in enumerate (os.breadcrumbs)">
-	    <li class="breadcrumb ${'first' if n == 0 else 'next'}"
-		itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb">
+	    <li class="breadcrumb ${'first' if n == 0 else 'next'}"  itemprop="itemListElement" itemscope="itemscope" itemtype="https://schema.org/ListItem">
 	      <span class="breadcrumb-separator"></span>
 	      <a href="${bc[2]}" title="${bc[1]}" itemprop="url"><span itemprop="title">${bc[0]}</span></a>
 	    </li>

--- a/templates/bibrec.html
+++ b/templates/bibrec.html
@@ -180,20 +180,12 @@ Gutenberg metadata much faster than by scraping.
                    title="Send to OneDrive." rel="nofollow"><span class="icon icon_msdrive" /></a>
                   </td>
                 </tr>
-
-                <!--! more files ... -->
                 <tr py:if="e.base_dir"
                 class="${i%2 and 'odd' or 'even'}">
                   <td><span class="icon icon_folder" /></td>
-                  <td class="unpadded icon_file"><a href="${e.base_dir}" class="link"
-                i18n:comment="Link to the directory containing all files.">More Files…</a></td>
-                  <td class="noscreen">${os.qualify (e.base_dir)}</td>
-                  <td/>
-                  <td class="noprint"><!--! dropbox column --></td>
-                  <td class="noprint"><!--! gdrive  column --></td>
-                  <td class="noprint"><!--! msdrive  column --></td>
+                    <td colspan='6'><span class="small"> 
+                  There may be <a class="subtle_link" rel="nofollow" href="${e.base_dir}" >more files</a> related to this item.</span></td>
                 </tr>
-
               </table>
             </div>
               </py:if>

--- a/templates/bibrec.html
+++ b/templates/bibrec.html
@@ -33,7 +33,7 @@ Gutenberg metadata much faster than by scraping.
         s = s.replace (' ', '_')
         return '%s#%s' % ('/help/bibliographic_record.html', s)
     def explain (s):
-        return _('Explain {topic}.').format (topic = _(s))
+        return _('Information about {topic}.').format (topic = _(s))
     def _ (s):
         return s
     i = 0
@@ -143,7 +143,7 @@ Gutenberg metadata much faster than by scraping.
 
                 <tr>
                   <th />
-                  <th>Format <span>${help ('Format')}</span></th>
+                  <th>Choose how to read this book <span>${help ('format')}</span></th>
                   <th class="noscreen">Url</th>
                   <th i18n:comment="Size of a file." class="right">Size</th>
                   <th class="noprint"><span>${help ('Dropbox')}</span></th>
@@ -159,7 +159,7 @@ Gutenberg metadata much faster than by scraping.
                   <td property="dcterms:format" content="${file_.mediatypes[-1]}" datatype="dcterms:IMT"
                   class="unpadded icon_save"
                   ><a href="/${file_.filename}" type="${file_.mediatypes[-1]}" class="link"
-                      title="Download">${file_.hr_filetype}</a></td>
+                      title="${'Read online' if file_.filetype.startswith('html') else 'Download'}">${file_.hr_filetype}</a></td>
                   <td class="noscreen">${file_.url}</td>
                   <td  class="right"
                    property="dcterms:extent" content="${file_.extent}">${file_.hr_extent}</td>

--- a/templates/bibrec.html
+++ b/templates/bibrec.html
@@ -104,6 +104,9 @@ Gutenberg metadata much faster than by scraping.
 	  <div id="social" class="noprint">
 	    <ul>
 	      <li>
+		     ${masto_share(os.canonical_url, "Free book at Project Gutenberg: " + os.title)}
+	      </li>
+	      <li>
 		     ${tw_share(os.canonical_url, os.twit)}
 	      </li>
 	      <li>

--- a/templates/bibrec.html
+++ b/templates/bibrec.html
@@ -324,8 +324,16 @@ Gutenberg metadata much faster than by scraping.
 		    </tr>
 
 		    <tr itemprop="offers" itemscope="itemscope" itemtype="http://schema.org/Offer">		      
-		      <td colspan="2"><span itemprop="priceCurrency" content="USD" /><span itemprop="price" content="$0.00"><em>Project Gutenberg eBooks are always free!</em></span><span itemprop="availability"  content="In Stock" ><a href="http://schema.org/InStock"></a></span></td>
-		    </tr>
+		      <td colspan="2">
+		      <span itemprop="priceCurrency" content="USD" />
+		      <span itemprop="price" content="$0.00">
+		        <em>Project Gutenberg eBooks are always free!</em>
+		      </span>
+		      <span itemprop="availability" content="In Stock" >
+		        <a href="http://schema.org/InStock"></a>
+		      </span>  
+              </td> 
+            </tr>    
 
 		  </table>
 
@@ -342,24 +350,6 @@ Gutenberg metadata much faster than by scraping.
 </div>
       <div id="dialog" class="hidden">
       </div>
-
-      <!--!
-	<a href="http://validator.w3.org/check?uri=referer" rel="nofollow"
-	   title="This page contains RDFa metadata."><img
-	   src="http://www.w3.org/Icons/valid-xhtml-rdfa-blue"
-	   width="88"
-	   height="31"
-	   alt="Valid XHTML + RDFa"
-	   about=""
-	   rel="dcterms:conformsTo"
-	   resource="http://www.w3.org/TR/rdfa-syntax" /></a>
-	<a href="${os.url_carry ('bibrec', format='rdf')}"
-	   title="Download RDF/XML Metadata for this eBook."><img
-	   src="http://www.w3.org/RDF/icons/rdf_metadata_button.32"
-	   width="76"
-	   height="32"
-	   alt="RDF/XML Metadata" /></a>
-      -->
     </div>
       ${site_footer()}
 

--- a/templates/results.opds
+++ b/templates/results.opds
@@ -1,16 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!--
-
-DON'T USE THIS PAGE FOR SCRAPING.
-
-Seriously. You'll only get your IP blocked.
-
-Download https://www.gutenberg.org/feeds/catalog.rdf.bz2 instead,
-which contains *all* Project Gutenberg metadata in one RDF/XML file.
-
--->
-
 <?python
   import re
   from libgutenberg import GutenbergGlobals as gg

--- a/templates/site-layout.html
+++ b/templates/site-layout.html
@@ -13,6 +13,8 @@
   <py:def function="site_head">
     <style >
       .icon   { background: transparent url(/pics/sprite.png) 0 0 no-repeat; }
+      .page_content a.subtle_link:link {color:currentColor; text-decoration: none;}
+      .page_content a.subtle_link:hover {color:#003366}
     </style>
 
     <link rel="stylesheet" type="text/css" href="/gutenberg/pg-desktop-one.css" />

--- a/templates/social-functions.html
+++ b/templates/social-functions.html
@@ -52,6 +52,23 @@
     </div>
   </py:def>
 
+  <py:def function="masto_share(url, text)">
+    <!-- toot without javascript -->
+    <?python
+      params = {
+	  'text': str(text + ' ' + url).encode('utf-8'),
+	  }
+    ?>
+    <div class="social-button masto-share-button">
+      <a href="https://toot.kytta.dev/?${p(params)}"
+	 title="Share on Mastodon"
+	 onclick="open_share_popup(this.href, this.target, 640, 320)"
+	 target="_top">
+ 	<span class="icon icon_masto" />
+      </a>
+    </div>
+  </py:def>
+
 
   <py:def function="rss_follow()">
     <div class="social-button rss-follow-button">


### PR DESCRIPTION
- removed NEW_FILETYPES switch.
- hide the non generated html file if there's a generated version #106 
- replace data-vocabulary.org properties with equivalent schema.o #104 
- include zipped generated html5 archives in file list
- added mastodon post button using toot.kytta.dev (requires https://github.com/gbnewby/gutenbergsite/pull/32)
- tweaked text based on greg's suggestions