### PR TITLE
update schema.org metadata 

### DIFF
--- a/templates/bibrec.html
+++ b/templates/bibrec.html
@@ -74,7 +74,7 @@ Gutenberg metadata much faster than by scraping.
 	  <py:for each="n, bc in enumerate (os.breadcrumbs)">
 	    <li class="breadcrumb ${'first' if n == 0 else 'next'}"  itemprop="itemListElement" itemscope="itemscope" itemtype="https://schema.org/ListItem">
 	      <span class="breadcrumb-separator"></span>
-	      <a href="${bc[2]}" title="${bc[1]}" itemprop="url"><span itemprop="title">${bc[0]}</span></a>
+	      <a href="${bc[2]}" title="${bc[1]}" itemprop="url"><span itemprop="name">${bc[0]}</span></a><meta itemprop="position" content="${n}" />
 	    </li>
 	  </py:for>
 	</ul>


### PR DESCRIPTION
they switched from 'title' to 'name'
also they want a 'position' for each breadcrumb
checked with https://validator.schema.org/
fixes #108 