### PR TITLE
Dev

### DIFF
--- a/AdvSearchPage.py
+++ b/AdvSearchPage.py
@@ -139,12 +139,13 @@ class AdvSearchPage(Page):
 
         os = AdvSearcher()
         params = cherrypy.request.params.copy()
+        fullpage = not bool(params.get("strip", ""))
         try:
             pageno = abs(int(params.pop("pageno", 1)))
         except KeyError:
             pageno = 1
         os.pageno = pageno
-        for key in ["submit_search", "route_name", "controller", "action"]:
+        for key in ["submit_search", "route_name", "controller", "action", "strip"]:
             params.pop(key, None)
         terms = [key for key in params if params[key]]
 
@@ -154,7 +155,10 @@ class AdvSearchPage(Page):
         if len(terms) == 0:
             os.total_results = 0
             os.finalize()
-            return self.formatter.render('advresults', os)
+            if fullpage:
+                return self.formatter.render('advresults', os)
+            else:
+                return self.formatter.render('searchbrowse', os)
 
         # single term, redirect if browsable
         if len(terms) == 1:

--- a/AdvSearchPage.py
+++ b/AdvSearchPage.py
@@ -176,6 +176,7 @@ class AdvSearchPage(Page):
             else:
                 searchterms.append((key, params[key]))
 
+        pks = []
         for key, val in searchterms:
             if key == 'filetype':
                 pks = query.join(File).filter(File.fk_filetypes == val).all()

--- a/CherryPyApp.py
+++ b/CherryPyApp.py
@@ -240,7 +240,7 @@ def main():
     d.connect('bookshelf', r'/ebooks/bookshelf/{id:\d+}{.format}',
                controller=BookshelfPage(), conditions=dict(function=check_id))
 
-    d.connect('also', r'/ebooks/{id:\d+}/also/{.format}',
+    d.connect('also', r'/ebooks/{id:\d+}/also/',
                controller=AlsoDownloadedPage(), conditions=dict(function=check_id))
 
     # bibrec pages

--- a/templates/results.opds
+++ b/templates/results.opds
@@ -250,11 +250,6 @@
 		href="${link.url}" />
 	</py:for>
 
-	<link type="${os.type_opds}"
-	      rel="related"
-	      href="${os.url ('also', id = e.project_gutenberg_id)}"
-	      title="Readers also downloaded…" />
-
 	<py:for each="author in e.authors">
 	  <link type="${os.type_opds}"
 		rel="related"

--- a/templates/searchbrowse.html
+++ b/templates/searchbrowse.html
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+  <?python
+  from itertools import cycle
+  from libgutenberg.DublinCore import DublinCore
+  from libgutenberg import GutenbergGlobals as gg
+  from AdvSearchPage import MAX_RESULTS, langoptions, langlots, langless
+  ?>
+  <xi:include href="advsearch.html" xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:xi="http://www.w3.org/2001/XInclude"
+      xmlns:py="http://genshi.edgewall.org/"
+      xmlns:i18n="http://genshi.edgewall.org/i18n"/>

--- a/test_post.html
+++ b/test_post.html
@@ -1,3 +1,0 @@
-<form action="http://127.0.0.1:8000/ebooks/results/" method=POST>
-<input type="submit">
-</form>

--- a/testlinks.html
+++ b/testlinks.html
@@ -1,0 +1,17 @@
+<h1> 
+test links</h1>
+<form action="http://127.0.0.1:8000/ebooks/results/" method=POST>
+<input type="submit" value="test advanced search POST">
+</form>
+<br>
+<a href="http://127.0.0.1:8000/ebooks/results/">advanced search (GET)</a>
+<br>
+<a href="http://127.0.0.1:8000/ebooks/results/?strip=true">advanced search/browse only </a>
+<br>
+<a href="http://127.0.0.1:8000/diagnostics/">diagnostics</a>
+<br>
+<a href="http://127.0.0.1:8000/ebooks/">start page</a>
+<br>
+<a href="http://127.0.0.1:8000/ebooks.opds/">OPDS start page</a>
+<br>
+<a href="http://127.0.0.1:8000/ebooks/sitemaps/0">sitemap</a>


### PR DESCRIPTION
- added testing links. Not sure why I thought advanced search must use POST
- fixed bug when an unknown param is added to adv search
- added a parameter ("strip") to the advanced search endpoint so that the browse list and the advanced search form can be generated dynamically and embedded in static pages generated by Jekyll
- removed opds link for also because they were dead