### PR TITLE
fix bug when generated summary is < 72 words

### DIFF
--- a/BibrecPage.py
+++ b/BibrecPage.py
@@ -27,6 +27,23 @@ import Page
 class BibrecPage (Page.Page):
     """ Implements the bibrec page. """
 
+    def split_summary(self, text, word_count=72):
+        """ Split summary into initial and remaining parts for toggling in the interface. """
+        if not text:
+            return None, None
+        words = text.split()
+        initial = ' '.join(words[:word_count])
+        remaining = ' '.join(words[word_count:]) if len(words) > word_count else ''
+        return initial, remaining
+
+
+    def get_book_summary(self, dc, book_id):
+        for marc in dc.marcs:
+            if marc.code == '520' and "This is an automatically generated summary" in marc.text:
+                return self.split_summary(marc.text)
+        return None, None
+
+
     def index (self, **dummy_kwargs):
         """ A bibrec page. """
 


### PR DESCRIPTION
Fixed bug introduced in 283cda65b59e586f939be57184023fe5804a82f2 that caused a system error when a generated summary was ≤ 72 words long.