### PR TITLE
in January, we stopped making html.noimages

### DIFF
--- a/HTMLFormatter.py
+++ b/HTMLFormatter.py
@@ -69,7 +69,7 @@ class XMLishFormatter (BaseFormatter.BaseFormatter):
         if do_dedupe:
             for ft in ['epub', 'pdf', 'html']:
                 if ft + '.images' in dedupable and ft + '.noimages' in dedupable:
-                    dc.files.remove(dedupable[ft + '.images'])
+                    dc.files.remove(dedupable[ft + '.noimages'])
                 
         for file_ in dc.files:
             type_ = six.text_type (file_.mediatypes[0])


### PR DESCRIPTION
This change hides the files we're not regenerating.

We had been hiding the "images" versions because duplicates were the images versions when there were no images.

We may need to change the display names of the .images files to be the norm, and the add (images removed) or something like that to the noimages files