### PR TITLE
CSS adjustment

### DIFF
--- a/templates/results.html
+++ b/templates/results.html
@@ -67,9 +67,15 @@ which contains *all* Project Gutenberg metadata in one RDF/XML file.
 		padding-top: 5px;
 	}
 
+	@media screen and (max-width: 1025px) {
+		div .header {
+			padding-top: 75px;
+		}
+	}
+	    
 	@media screen and (max-width: 750px) {
 		div .header {
-			padding-top: 70px;
+			padding-top: 140px;
 		}
 	}
     </style>


### PR DESCRIPTION
second attempt to fix overlay of header onto main page content on search results page.
This CSS fixes the problem for me if I directly apply it in Chrome on the dev page. Fingers crossed.