### PR TITLE
Same changes as on gutenbergsite

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -6,7 +6,7 @@
         <a href="/policy/privacy_policy.html" title="Privacy Policy">Privacy policy</a>
       </li>
       <li>
-        <a href="/policy/permission.html" title="Privacy Policy">Permissions</a>
+        <a href="/policy/permission.html" title="Permissions">Permissions</a>
       </li>
       <li>
         <a href="/policy/terms_of_use.html" title="Terms of Use">Terms of Use</a>

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,3 +1,4 @@
+<div>
   <ul>
       <li>
         <a href="/about/" title="About Project Gutenberg">About Project Gutenberg</a>
@@ -18,5 +19,6 @@
   </ul>
 
   <a href="https://www.ibiblio.org/" title="Project Gutenberg is hosted by ibiblio">
-   <img src="/gutenberg/ibiblio-logo.png" alt="iBiblio">
+   <img src="/gutenberg/ibiblio-logo.png" alt="iBiblio" />
   </a>
+</div>

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,22 +1,22 @@
-<div>
   <ul>
+      <li>
+        <a href="/about/" title="About Project Gutenberg">About Project Gutenberg</a>
+      </li>
       <li>
         <a href="/policy/privacy_policy.html" title="Privacy Policy">Privacy policy</a>
       </li>
       <li>
-        <a href="/about/" title="About Project Gutenberg">About Project Gutenberg</a>
+        <a href="/policy/permission.html" title="Privacy Policy">Permissions</a>
       </li>
       <li>
         <a href="/policy/terms_of_use.html" title="Terms of Use">Terms of Use</a>
       </li>
       <li>
-        <a href="/about/contact_information.html" title="Contact Information">Contact Information</a>
+        <a href="/about/contact_information.html" title="Contact Information">Contact Us</a>
       </li>
-      <li><a href="/help/" title="Get Help">Get Help</a></li>
-
+      <li><a href="/help/" title="Get Help">Help Pages</a></li>
   </ul>
 
   <a href="https://www.ibiblio.org/" title="Project Gutenberg is hosted by ibiblio">
-   <img src="/gutenberg/ibiblio-logo.png" alt="iBiblio" />
+   <img src="/gutenberg/ibiblio-logo.png" alt="iBiblio">
   </a>
-</div>

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -1,5 +1,6 @@
 <header>
   <input type="checkbox" id="search-toggle" style="display: none" />
+  <input type="checkbox" id="about-toggle" style="display: none" />
   <div class="logo-container">
     <a id="main_logo" href="/" class="no-hover">
       <img src="/gutenberg/pg-logo-129x80.png" alt="Project Gutenberg" draggable="false" />
@@ -67,17 +68,15 @@
     </div>
   </div>
 
+  <label for="about-toggle" class="dropdown-overlay"></label>
   <div class="lower-header">
     <div class="dropdown">
-      <button class="dropdown-button">About</button>
+      <label for="about-toggle" class="dropdown-button" aria-haspopup="true" aria-expanded="false">About<span aria-hidden="true" class="dropdown-icon">▼</span></label>
       <div class="dropdown-content">
         <a href="/about/">About Project Gutenberg </a>
-        <a href="/policy/collection_development.html"
-          >Collection Development</a
-        >
         <a href="/about/contact_information.html">Contact Us</a>
         <a href="/about/background/">History &amp; Philosophy</a>
-        <a href="/policy/permission.html">Permissions &amp; License</a>
+        <a href="/help/mobile.html">Kindle & eReaders</a>
         <a href="/help/">Help Pages</a>
         <a href="/ebooks/offline_catalogs.html">Offline Catalogs</a>
         <a href="/donate/">Donate</a>

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -76,7 +76,7 @@
         <a href="/about/">About Project Gutenberg </a>
         <a href="/about/contact_information.html">Contact Us</a>
         <a href="/about/background/">History &amp; Philosophy</a>
-        <a href="/help/mobile.html">Kindle & eReaders</a>
+        <a href="/help/mobile.html">Kindle &amp; eReaders</a>
         <a href="/help/">Help Pages</a>
         <a href="/ebooks/offline_catalogs.html">Offline Catalogs</a>
         <a href="/donate/">Donate</a>


### PR DESCRIPTION
- "About" clickable to close drop-down menu when it's extended
 - fix for "voiceover" text (as suggested on slack)
 - small reorg of "About" Menu and Footer links (based on feedback from Greg)
