### PR TITLE
display reading level (moved to 908) on bibrec

### DIFF
--- a/BaseFormatter.py
+++ b/BaseFormatter.py
@@ -145,7 +145,9 @@ class BaseFormatter(object):
         """ Add some info to dc for easier templating. """
 
         # obsolete private marc codes for cover art
-        dc.marcs = [ marc for marc in dc.marcs if not marc.code.startswith('9') ]
+        dc.marcs = [ marc for marc in dc.marcs if (
+            not marc.code.startswith('9') or marc.code == '908')
+        ]
 
         dc.cover_image = None
         dc.cover_thumb = None


### PR DESCRIPTION
We are moving the reading level entries from marc 500 to marc 908 so we can add 500 entries back to keyword search. Attribute display was off for marc code 900 and over.