### PR TITLE
improve compatibility with rest of website

### DIFF
--- a/templates/advresults.html
+++ b/templates/advresults.html
@@ -57,7 +57,7 @@
 
   <body class="advresults_page">
   <div class="container">
-    <div id="mw-head-dummy" class="noprint" />
+    <xi:include href="menu.html" />
 
     <div id="content" class="page_content" i18n:comment="On the page of results of a search.">
         <!-- start content -->
@@ -71,10 +71,10 @@
         <p>${os.total_results} books found. </p>
 </py:if>
 <py:if test='not os.search_terms'>
-    <p>No valid search terms found.</p>
+    <p class="center page">No valid search terms found.</p>
 </py:if>
 <py:if test='os.total_results &gt; MAX_RESULTS'>
-    <p>More than ${MAX_RESULTS} books matched your search. Please refine your query to see results.</p>
+    <p class="center page">More than ${MAX_RESULTS} books matched your search. Please refine your query to see results.</p>
 </py:if>
 
 <py:if test='os.total_results and (os.total_results &lt;= MAX_RESULTS)'>
@@ -148,6 +148,5 @@
       ${site_footer ()}
 
 
-    <xi:include href="menu.html" />
   </body>
 </html>

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -3,6 +3,10 @@
   <input type="radio" name="toggle" id="search-close" style="display: none" />
   <input type="checkbox" id="about-toggle" style="display: none" />
   <div class="logo-container">
+    <a href="#content" class="visually-hidden focusable skip-link">
+      Skip to main content
+    </a>
+
     <a id="main_logo" href="/" class="no-hover">
       <img src="/gutenberg/pg-logo-129x80.png" alt="Project Gutenberg" draggable="false" />
     </a>

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -1,4 +1,4 @@
-<header>
+<header class="noprint">
   <input type="radio" name="toggle" id="search-toggle" style="display: none" />
   <input type="radio" name="toggle" id="search-close" style="display: none" />
   <input type="checkbox" id="about-toggle" style="display: none" />

--- a/templates/results.html
+++ b/templates/results.html
@@ -63,12 +63,11 @@ which contains *all* Project Gutenberg metadata in one RDF/XML file.
   </head>
 
   <body class="search_results_page">
-    <div id="mw-head-dummy" class="noprint" />
-
+    <xi:include href="menu.html" />
+    <div class="container" >
     <div id="content" class="page_content" i18n:comment="On the page of results of a search.">
-      <div class="header">
+
 	<h1><span class="icon icon_${os.title_icon}" />${os.title}</h1>
-      </div>
 
       <div class="body">
 	<div>
@@ -127,13 +126,11 @@ which contains *all* Project Gutenberg metadata in one RDF/XML file.
 
 	  </ul>
 	</div>
-
       </div> <!--! body -->
 	</div>
       ${site_footer ()}
+    </div>
 
-
-    <xi:include href="menu.html" />
 
   </body>
 </html>


### PR DESCRIPTION
1. add noprint to header
2. add skip-to-content link. needed this in the menu in order to not be covered by the menubar. Implements https://github.com/gutenbergtools/gutenbergsite/issues/132
3. move menu to top of page results pages; remove dummy elements. the result is more uniform page layouts- it was really hard to get css to work on all the different layouts