### PR TITLE
re-order footer on results template

### DIFF
--- a/templates/results.html
+++ b/templates/results.html
@@ -128,8 +128,8 @@ which contains *all* Project Gutenberg metadata in one RDF/XML file.
 	</div>
       </div> <!--! body -->
 	</div>
-      ${site_footer ()}
-    </div>
+  </div>
+  ${site_footer ()}
 
 
   </body>


### PR DESCRIPTION
This moves the footer outside of the container div. This should fix the issue pictured below and make all content pages have the same HTML structure.

![image](https://github.com/user-attachments/assets/8e4e11d5-7f3f-4caa-a2d1-aae59edb7687)

> [!WARNING]
> I was not able to test the change outside of adjustments using dev tools. So if anyone can test this locally before merge, that would be ideal. 