### PR TITLE
assorted UI changes

### DIFF
--- a/AdvSearchPage.py
+++ b/AdvSearchPage.py
@@ -38,6 +38,7 @@ from errors import ErrorPage
 from Page import Page
 from Formatters import formatters
 
+from catalog import catname
 
 config = cherrypy.config
 
@@ -45,61 +46,6 @@ BROWSE_KEYS = {'lang': 'l', 'locc': 'lcc'}
 PAGESIZE = 100
 MAX_RESULTS = 5000
 
-_LANGOPTIONS = ''
-_LANGLOTS = ''
-_LANGLESS = ''
-
-# can't make a session until CherryPy is finished starting
-def makelists():
-    global _LANGOPTIONS, _LANGLOTS, _LANGLESS
-    if _LANGOPTIONS or _LANGLOTS or _LANGLESS:
-        return
-    session = cherrypy.engine.pool.Session()
-    for lang in session.execute(select(Lang.id, Lang.language).order_by(Lang.language)).all():
-        langnum = session.query(Book).filter(Book.langs.any(id=lang[0])).count()
-        _LANGOPTIONS += f'<option value="{lang[0]}">{lang[1]}</option>'
-        lang_link  = f'/ebooks/search/?query=l.{lang[0]}'
-        if langnum > 50:
-            _LANGLOTS += f'<a href="{lang_link}" title="{lang[1]} ({langnum})">{lang[1]}</a> '
-        elif langnum > 0:
-            _LANGLESS += f'<a href="{lang_link}" title="{lang[1]} ({langnum})">{lang[1]}</a> '
-
-def langoptions():
-    ''' option list for langs dropdown '''
-    global _LANGOPTIONS
-    if _LANGOPTIONS:
-        return _LANGOPTIONS
-    else:
-        makelists()
-        return _LANGOPTIONS
-
-def langlots():
-    ''' list of links for langs with more than 50 books '''
-    global _LANGLOTS
-    if _LANGLOTS:
-        return _LANGLOTS
-    else:
-        makelists()
-        return _LANGLOTS
-
-def langless():
-    ''' list of links for langs with up to 50 books '''
-    global _LANGLESS
-    if _LANGLESS:
-        return _LANGLESS
-    else:
-        makelists()
-        return _LANGLESS
-
-
-_cats = {}
-def catname(catpk):
-    """ cache of category names"""
-    if not _cats:
-        session = cherrypy.engine.pool.Session()
-        for cat in session.query(Category).all():
-            _cats[cat.pk] = cat.category
-    return _cats.get(catpk, 'Not a valid Category')
 
 
 class AdvSearcher(BaseSearcher.OpenSearch):

--- a/AdvSearchPage.py
+++ b/AdvSearchPage.py
@@ -41,7 +41,7 @@ from Formatters import formatters
 
 config = cherrypy.config
 
-BROWSE_KEYS = {'lang': 'languages', 'locc': 'loccs', 'category': 'categories'}
+BROWSE_KEYS = {'lang': 'l', 'locc': 'lcc', 'category': 'cat'}
 PAGESIZE = 100
 MAX_RESULTS = 5000
 
@@ -58,10 +58,11 @@ def makelists():
     for lang in session.execute(select(Lang.id, Lang.language).order_by(Lang.language)).all():
         langnum = session.query(Book).filter(Book.langs.any(id=lang[0])).count()
         _LANGOPTIONS += f'<option value="{lang[0]}">{lang[1]}</option>'
+        lang_link  = f'/ebooks/search/?query=l.{lang[0]}'
         if langnum > 50:
-            _LANGLOTS += f'<a href="/browse/languages/{lang[0]}" title="{lang[1]} ({langnum})">{lang[1]}</a> '
+            _LANGLOTS += f'<a href="{lang_link}" title="{lang[1]} ({langnum})">{lang[1]}</a> '
         elif langnum > 0:
-            _LANGLESS += f'<a href="/browse/languages/{lang[0]}" title="{lang[1]} ({langnum})">{lang[1]}</a> '
+            _LANGLESS += f'<a href="{lang_link}" title="{lang[1]} ({langnum})">{lang[1]}</a> '
 
 def langoptions():
     ''' option list for langs dropdown '''
@@ -164,12 +165,13 @@ class AdvSearchPage(Page):
             else:
                 return self.formatter.render('searchbrowse', os)
 
-        # single term, redirect if browsable
+        # single term, redirect if quick searchable
+        # (used to redirect to browsable)
         if len(terms) == 1:
             browse_key = BROWSE_KEYS.get(terms[0], None)
             if browse_key:
                 raise cherrypy.HTTPRedirect(
-                    "/browse/%s/%s" % (browse_key, params[terms[0]].lower()))
+                    "/ebooks/search/?query=%s.%s" % (browse_key, params[terms[0]].lower()))
 
         # multiple terms, create a query
         session = cherrypy.engine.pool.Session()

--- a/AdvSearchPage.py
+++ b/AdvSearchPage.py
@@ -41,7 +41,7 @@ from Formatters import formatters
 
 config = cherrypy.config
 
-BROWSE_KEYS = {'lang': 'l', 'locc': 'lcc', 'category': 'cat'}
+BROWSE_KEYS = {'lang': 'l', 'locc': 'lcc'}
 PAGESIZE = 100
 MAX_RESULTS = 5000
 
@@ -172,7 +172,10 @@ class AdvSearchPage(Page):
             if browse_key:
                 raise cherrypy.HTTPRedirect(
                     "/ebooks/search/?query=%s.%s" % (browse_key, params[terms[0]].lower()))
-
+            elif terms[0] == "category":
+                # category not in tsvec??
+                raise cherrypy.HTTPRedirect(f"/browse/categories/{params[terms[0]]}")
+            
         # multiple terms, create a query
         session = cherrypy.engine.pool.Session()
         query = session.query(Book.pk)

--- a/BaseSearcher.py
+++ b/BaseSearcher.py
@@ -501,7 +501,7 @@ class OpenSearch(object):
         self.snippet_image_url = self.url('/pics/logo-144x144.png', host=self.file_host)
         self.og_type = 'website'
         self.class_ = ClassAttr()
-        self.title_icon = None
+        self.title_icon = 'search'
         self.icon = None
         self.sort_orders = []
         self.alternate_sort_orders = []

--- a/CherryPyApp.py
+++ b/CherryPyApp.py
@@ -256,7 +256,7 @@ def main():
     d.connect('bibrec2', r'/ebooks/{id:\d+}.bibrec{.format}',
                controller=BibrecPage(), conditions=dict(function=check_id))
 
-    d.connect('cover', r'/covers/{size:small|medium}/{order:latest|popular}/{count}',
+    d.connect('cover', r'/covers/{size:small|medium}/{order:latest|popular|random}/{count}',
                controller=CoverPages.CoverPages())
 
     d.connect('qrcode', r'/qrcode/',

--- a/CoverPages.py
+++ b/CoverPages.py
@@ -17,6 +17,7 @@ from __future__ import unicode_literals
 import cherrypy
 import six
 from sqlalchemy import select
+from sqlalchemy.sql import func
 
 from libgutenberg import GutenbergGlobals as gg
 from libgutenberg import DublinCore, DublinCoreMapping, Models
@@ -98,6 +99,8 @@ class CoverPages(object):
 
             if order == 'popular':
                 order_by = Models.Book.downloads.desc()
+            if order == 'random':
+                order_by = func.random()
             else:
                 order_by = Models.Book.release_date.desc()
             rows = session.execute(select(Models.Book.pk).where(

--- a/SearchPage.py
+++ b/SearchPage.py
@@ -45,24 +45,33 @@ class BookSearchPage (SearchPage):
 
     def fixup (self, os):
         """ strip marc subfields, add social media hints and facet links """
-
+        os.icon = 'book'
         for e in os.entries:
             if '$' in e.title:
                 e.title = DublinCore.strip_marc_subfields (e.title)
 
         if (os.sort_order == 'release_date' and os.total_results > 0 and os.start_index == 1):
             cat = BaseSearcher.Cat ()
-            cat.title = _('Follow new books on Twitter')
-            cat.subtitle = _("Follow our new books on Twitter.")
-            cat.url = 'https://twitter.com/gutenberg_new'
+            cat.title = _('Follow new books on Mastodon')
+            cat.subtitle = _("Like and follow to see our new books in your feed.")
+            cat.url = 'https://mastodon.social/@gutenberg_new'
             cat.class_ += 'navlink grayed'
-            cat.icon = 'twitter'
+            cat.icon = 'mastodon'
+            cat.order = 5
+            os.entries.insert (0, cat)
+
+            cat = BaseSearcher.Cat ()
+            cat.title = _('Follow new books on Bluesky')
+            cat.subtitle = _("Boost and follow to see our new books in your feed.")
+            cat.url = 'https://bsky.app/profile/new.gutenberg.org'
+            cat.class_ += 'navlink grayed'
+            cat.icon = 'bluesky'
             cat.order = 5
             os.entries.insert (0, cat)
 
             cat = BaseSearcher.Cat ()
             cat.title = _('Follow new books on Facebook')
-            cat.subtitle = _("Follow the link and like the page to have us post new books to your wall.")
+            cat.subtitle = _("Like and follow to see our new books in your feed.")
             cat.url = 'https://www.facebook.com/gutenberg.new'
             cat.class_ += 'navlink grayed'
             cat.icon = 'facebook'

--- a/catalog.py
+++ b/catalog.py
@@ -1,0 +1,83 @@
+# code moved from AdvSearchPage so it could be used in Basesearcher
+import cherrypy
+from sqlalchemy import or_, and_, select
+
+from libgutenberg.Models import (
+    Alias, Attribute, Author, Book, BookAuthor, Category, File, Lang, Locc, Subject)
+
+
+_LANGOPTIONS = ''
+_LANGLOTS = ''
+_LANGLESS = ''
+_LANGS = {}
+
+# can't make a session until CherryPy is finished starting
+def makelangs():
+    global _LANGOPTIONS, _LANGLOTS, _LANGLESS, _LANGS
+    if _LANGOPTIONS or _LANGLOTS or _LANGLESS:
+        return _LANGS
+    session = cherrypy.engine.pool.Session()
+    for lang in session.execute(select(Lang.id, Lang.language).order_by(Lang.language)).all():
+        _LANGS[lang[0]] = lang[1]
+        langnum = session.query(Book).filter(Book.langs.any(id=lang[0])).count()
+        _LANGOPTIONS += f'<option value="{lang[0]}">{lang[1]}</option>'
+        lang_link  = f'/ebooks/search/?query=l.{lang[0]}'
+        if langnum > 50:
+            _LANGLOTS += f'<a href="{lang_link}" title="{lang[1]} ({langnum})">{lang[1]}</a> '
+        elif langnum > 0:
+            _LANGLESS += f'<a href="{lang_link}" title="{lang[1]} ({langnum})">{lang[1]}</a> '
+    return _LANGS
+
+def langoptions():
+    ''' option list for langs dropdown '''
+    global _LANGOPTIONS
+    if _LANGOPTIONS:
+        return _LANGOPTIONS
+    else:
+        makelangs()
+        return _LANGOPTIONS
+
+def langlots():
+    ''' list of links for langs with more than 50 books '''
+    global _LANGLOTS
+    if _LANGLOTS:
+        return _LANGLOTS
+    else:
+        makelangs()
+        return _LANGLOTS
+
+def langless():
+    ''' list of links for langs with up to 50 books '''
+    global _LANGLESS
+    if _LANGLESS:
+        return _LANGLESS
+    else:
+        makelangs()
+        return _LANGLESS
+
+def langname(code):
+    return makelangs().get(code.lower(), 'Not a valid language')
+
+_cats = {}
+
+def catname(catpk):
+    """ cache of category names"""
+    if not _cats:
+        session = cherrypy.engine.pool.Session()
+        for cat in session.query(Category).all():
+            _cats[cat.pk] = cat.category
+    try:
+        catpk = int(catpk)
+    except ValueError:
+        return 'Not a valid Category'
+    return _cats.get(catpk, 'Not a valid Category')
+
+_locs = {}
+
+def locname(id):
+    """ cache of classification names"""
+    if not _locs:
+        session = cherrypy.engine.pool.Session()
+        for loc in session.query(Locc).all():
+            _locs[loc.id] = loc.locc
+    return _locs.get(id.upper(), 'Not a valid Classification')

--- a/templates/site-layout.html
+++ b/templates/site-layout.html
@@ -160,12 +160,4 @@
     </form>
   </py:def>
 
-  <py:def function="flattr">
-    <a class="flattr-button" target="_blank"
-       href="https://flattr.com/thing/509045/Project-Gutenberg"
-       title="Send us money through Flattr.">
-      <span class="icon icon_flattr" />
-    </a>
-  </py:def>
-
 </html>


### PR DESCRIPTION
- single item advanced searches on language and LC class no longer redirect to static pages, but to quick search instead. (still do non-text 'categories')
- quicksearch pages now have human-readable titles for languages and LC class (these can be long)
- flattr reference is removed
- added "random" as a covers possibility #172 
- search pages now use the "search" icon insted of a broken icon
- fixed a typo 