### PR TITLE
change Categories and Catalogs to Catalogs and Languages

### DIFF
--- a/catalog.py
+++ b/catalog.py
@@ -23,9 +23,9 @@ def makelangs():
         _LANGOPTIONS += f'<option value="{lang[0]}">{lang[1]}</option>'
         lang_link  = f'/ebooks/search/?query=l.{lang[0]}'
         if langnum > 50:
-            _LANGLOTS += f'<a href="{lang_link}" title="{lang[1]} ({langnum})">{lang[1]}</a> '
+            _LANGLOTS += f'<a href="{lang_link}" title="{lang[1]} ({langnum})">{lang[1]}</a> | '
         elif langnum > 0:
-            _LANGLESS += f'<a href="{lang_link}" title="{lang[1]} ({langnum})">{lang[1]}</a> '
+            _LANGLESS += f'<a href="{lang_link}" title="{lang[1]} ({langnum})">{lang[1]}</a> | '
     return _LANGS
 
 def langoptions():
@@ -40,20 +40,16 @@ def langoptions():
 def langlots():
     ''' list of links for langs with more than 50 books '''
     global _LANGLOTS
-    if _LANGLOTS:
-        return _LANGLOTS
-    else:
+    if not _LANGLOTS:
         makelangs()
-        return _LANGLOTS
+    return _LANGLOTS[0:-2]  # cut trailing |
 
 def langless():
     ''' list of links for langs with up to 50 books '''
     global _LANGLESS
-    if _LANGLESS:
-        return _LANGLESS
-    else:
+    if not _LANGLESS:
         makelangs()
-        return _LANGLESS
+    return _LANGLESS[0:-2]  # cut trailing |
 
 def langname(code):
     return makelangs().get(code.lower(), 'Not a valid language')

--- a/templates/advsearch.html
+++ b/templates/advsearch.html
@@ -55,7 +55,7 @@
   <div class="tabs-container">
     <label for="tab-advanced">Advanced Search</label>
     <label for="tab-fulltext">Full Text Search</label>
-    <label for="tab-categories">Categories &amp; Catalogs</label>
+    <label for="tab-categories">Catalogs &amp; Languages</label>
   </div>
 
   <!-- Tab 1 - Advanced Search -->
@@ -508,28 +508,14 @@
       </form>
     </div>
   </div>
-  <!-- Tab 3 - Categories and Catalogs -->
+  <!-- Tab 3 - Catalogs and Languages -->
   <div id="card-catalog" class="tabcontent">
-    <h2>Categories</h2>
     <div class="pgdbnavbar" style="text-align: center">
-      <div>
-        <p> Main Categories are the categories you'd expect in a large book store. </p>
-        <div>
-          <a href="/ebooks/categories">Go to Main Categories</a>
-        </div>
-      </div>
-      <br />
-      <div>
-        <p> Reading Lists are hand-curated collections about relatively specific topics. </p>
-        <div>
-          <a href="/ebooks/bookshelf/"> Go to Reading lists </a>
-        </div>
-      </div>
-      <br />
-      <br />
       <h2>Catalogs</h2>
+      <br />
+      
+      <h3>Authors Catalog</h3>
       <div>
-        <p>Authors Catalog</p>
     <a href="/browse/authors/a">A</a>&nbsp;
     <a href="/browse/authors/b">B</a>&nbsp;
     <a href="/browse/authors/c">C</a>&nbsp;
@@ -557,11 +543,10 @@
     <a href="/browse/authors/y">Y</a>&nbsp;
     <a href="/browse/authors/z">Z</a>&nbsp;
     <a href="/browse/authors/other">other</a>&nbsp;
-  </div>
+      </div>
       <br />
+      <h3>Titles Catalog</h3>
       <div>
-        <p>Titles Catalog</p>
-        <div>
     <a href="/browse/titles/a">A</a>&nbsp;
     <a href="/browse/titles/b">B</a>&nbsp;
     <a href="/browse/titles/c">C</a>&nbsp;
@@ -589,32 +574,36 @@
     <a href="/browse/titles/y">Y</a>&nbsp;
     <a href="/browse/titles/z">Z</a>&nbsp;
     <a href="/browse/titles/other">other</a>&nbsp;
-        </div>
       </div>
+      <br />
 
-    <p>Languages with more than 50 books:
-      ${Markup(langlots())}
-    </p>
-    <p>Languages with up to 50 books:
-      ${Markup(langless())}
-    </p>
-    <p>Special Categories:
-      <a href="/browse/categories/2" title="Audio Book, computer-generated (370)">Audio Book, computer-generated</a>&nbsp;
-      <a href="/browse/categories/1" title="Audio Book, human-read (576)">Audio Book, human-read</a>&nbsp;
-      <a href="/browse/categories/9" title="Compilations (3)">Compilations</a>&nbsp;
-      <a href="/browse/categories/8" title="Data (87)">Data</a>&nbsp;
-      <a href="/browse/categories/3" title="Music, recorded (137)">Music, recorded</a>&nbsp;
-      <a href="/browse/categories/4" title="Music, Sheet (33)">Music, Sheet</a>&nbsp;
-      <a href="/browse/categories/6" title="Other recordings (31)">Other recordings</a>&nbsp;
-      <a href="/browse/categories/7" title="Pictures, moving (8)">Pictures, moving</a>&nbsp;
-      <a href="/browse/categories/5" title="Pictures, still (3)">Pictures, still</a>&nbsp;
-    </p>
-    <p>Recent:
-      <a href="/browse/recent/last1">last 24 hours</a>&nbsp;
-      <a href="/browse/recent/last7">last 7 days</a>&nbsp;
-      <a href="/browse/recent/last30">last 30 days</a>&nbsp;
-    </p>
+      <h2>Languages</h2>    
+      <br />
+      <h3>Languages with more than 50 books</h3>
+      <div>
+        ${Markup(langlots())}
+      </div>
+      <br />
+      <h3>Languages with up to 50 books</h3>
+      <div>
+        ${Markup(langless())}
+      </div>
+      <br/>
+      <h2>Non-text</h2>
+      <br />
+
+      <div>
+          <a href="/browse/categories/2" title="Audio Book, computer-generated (370)">Audio Book, computer-generated</a>&nbsp;|
+          <a href="/browse/categories/1" title="Audio Book, human-read (576)">Audio Book, human-read</a>&nbsp;|
+          <a href="/browse/categories/9" title="Compilations (3)">Compilations</a>&nbsp;|
+          <a href="/browse/categories/8" title="Data (87)">Data</a>&nbsp;|
+          <a href="/browse/categories/3" title="Music, recorded (137)">Music, recorded</a>&nbsp;|
+          <a href="/browse/categories/4" title="Music, Sheet (33)">Music, Sheet</a>&nbsp;|
+          <a href="/browse/categories/6" title="Other recordings (31)">Other recordings</a>&nbsp;|
+          <a href="/browse/categories/7" title="Pictures, moving (8)">Pictures, moving</a>&nbsp;|
+          <a href="/browse/categories/5" title="Pictures, still (3)">Pictures, still</a>&nbsp;
+      </div>
+    </div>
   </div>
-</div>
   </div>
 </div>

--- a/testlinks.html
+++ b/testlinks.html
@@ -3,6 +3,18 @@ test links</h1>
 <form action="http://127.0.0.1:8000/ebooks/results/" method=POST>
 <input type="submit" value="test advanced search POST">
 </form>
+<form action="http://127.0.0.1:8000/ebooks/results/" method=POST>
+<input type="submit" value="test advanced just a lang POST">
+<select id="lang" name="lang" title="Language">
+<option value="fr">French</option> </select>
+</form>
+
+<form action="http://127.0.0.1:8000/ebooks/results/" method=POST>
+<input type="submit" value="test jules verne and french POST">
+<input type="text" name="author" id="author" value="Jules Verne">
+<select id="lang" name="lang" title="Language">
+<option value="fr">French</option> </select>
+</form>
 <br>
 <a href="http://127.0.0.1:8000/ebooks/results/">advanced search (GET)</a>
 <br>


### PR DESCRIPTION
(also add testlinks for debugging)

Autocat3 returns different content in advance research results than everywhere else. We should make it the same as everywhere else.

This is my proposal to address this content skew.
- the current tab just duplicates Catergories that are already avalable from the top menu.
- the current tab elsewhere removes the languages links elsewhere. Now that we no longer link to static language pages, the language links are important to have everywhere for non-english speakers.
- this is the only accessible place we have "catalogs" for non-text materials. Although they're the old static pages, having them here will motivate us to move to dynamic content.

I will create a corresponding PR in gutenbergsite.

<img width="1644" height="1412" alt="image" src="https://github.com/user-attachments/assets/8a637b04-0632-4e57-ae32-96c6824ab6bf" />
