### PR TITLE
[WIP] Set up environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+PG_USER=gutenberg
+STATIC_DIR=static # 'gutenberg' for dev/prod

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# local static files
+static/

--- a/AdvSearchPage.py
+++ b/AdvSearchPage.py
@@ -22,6 +22,7 @@ Differences:
 
 
 """
+import os
 import re
 
 import cherrypy
@@ -40,13 +41,19 @@ from Formatters import formatters
 
 from catalog import catname
 
+from dotenv import load_dotenv
+load_dotenv()
+
+cherrypy.config.update({
+    'pguser': os.getenv('PG_USER'),
+    'staticdir': os.getenv('STATIC_DIR')
+})
+
 config = cherrypy.config
 
 BROWSE_KEYS = {'lang': 'l', 'locc': 'lcc'}
 PAGESIZE = 100
 MAX_RESULTS = 5000
-
-
 
 class AdvSearcher(BaseSearcher.OpenSearch):
     """ this object passes the context for the page renderer """

--- a/BaseSearcher.py
+++ b/BaseSearcher.py
@@ -15,6 +15,7 @@ Base class
 from __future__ import unicode_literals
 from __future__ import division
 
+import os
 import datetime
 import logging
 
@@ -381,6 +382,7 @@ class OpenSearch(object):
     }
 
     def __init__(self):
+        self.staticdir = os.getenv('STATIC_DIR')
         self.format = None
         self.page = None
         self.template = None

--- a/CherryPy.conf
+++ b/CherryPy.conf
@@ -19,7 +19,6 @@ server.thread_pool_max: 20
 pghost:     'localhost'
 pgport:     5432
 pgdatabase: 'gutenberg'
-pguser:     'postgres'
 
 host:        'www.gutenberg.org'
 host_https:  1
@@ -80,6 +79,10 @@ tools.sessions.domain: '.gutenberg.org'
 tools.expires.on: True
 tools.expires.secs: 0
 tools.expires.force: True
+
+[/static]
+tools.staticdir.on: True
+tools.staticdir.dir: CherryPyApp.install_dir + "/static"
 
 [/index.html]
 tools.staticfile.on: True

--- a/Page.py
+++ b/Page.py
@@ -11,9 +11,9 @@ Distributable under the GNU General Public License Version 3 or newer.
 Base class for all pages.
 
 """
-
 from __future__ import unicode_literals
 
+import os
 import logging
 
 import cherrypy
@@ -31,6 +31,7 @@ class Page(object):
 
     def __init__(self):
         self.supported_book_mediatypes = [ mt.epub, mt.mobi ]
+        self.staticdir = os.getenv('STATIC_DIR')
 
 
     @staticmethod

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -8,7 +8,7 @@
     </a>
 
     <a id="main_logo" href="/" class="no-hover">
-      <img src="/gutenberg/pg-logo-129x80.png" alt="Project Gutenberg" draggable="false" />
+      <img src="/${os.staticdir}/pg-logo-129x80.png" alt="Project Gutenberg" draggable="false" />
     </a>
   </div>
 

--- a/templates/site-layout.html
+++ b/templates/site-layout.html
@@ -17,10 +17,10 @@
       .page_content a.subtle_link:hover {color:#003366}
     </style>
 
-    <link rel="stylesheet" type="text/css" href="/gutenberg/pg-desktop-one.css?v=1.1" />
-    <link rel="stylesheet" type="text/css" href="/gutenberg/style2.css?v=1.5"/>
-    <link rel="stylesheet" type="text/css" href="/gutenberg/new_nav.css?v=1.6"/>
-    <link rel="stylesheet" type="text/css" href="/gutenberg/search_options.css?v=1" />
+    <link rel="stylesheet" type="text/css" href="/${os.staticdir}/pg-desktop-one.css?v=1.1" />
+    <link rel="stylesheet" type="text/css" href="/${os.staticdir}/style2.css?v=1.5"/>
+    <link rel="stylesheet" type="text/css" href="/${os.staticdir}/new_nav.css?v=1.6"/>
+    <link rel="stylesheet" type="text/css" href="/${os.staticdir}/search_options.css?v=1" />
 
     <!--! IE8 does not recognize application/javascript -->
     <script>//<![CDATA[
@@ -159,5 +159,4 @@
       </div>
     </form>
   </py:def>
-
 </html>


### PR DESCRIPTION
## Description

When working on autocat3 locally, I have a number of un-staged changes to get the site to load similarly to dev. These include css and image files, as well as changes to the postgres setup. This PR attempts to streamline that workflow a bit. It does this by setting up environment variables which can then be used to dynamically change different parts of the application.

## Additional ideas
The biggest issue IMO is that the CSS/Images are not linked between [gutenbergsite](https://github.com/gutenbergtools/gutenbergsite) and autocat3. This decoupling makes it very difficult to validate changes that are made across both repositories. I am assuming there is a good reason for this decoupling (though it is worth re-considering this as I don't know what that reason is). But, based on the assumption they need to be separate, we can still make some improvements.

We could use `git submodule` to link the [gutenbergsite/gutenberg](https://github.com/gutenbergtools/gutenbergsite/tree/master/gutenberg) to the autocat3 static directory. This will allow devs to pull down recent gutenbergsite changes to autocat3. The static directory can be removed from the production build of the site, so it will only impact local development. 