### PR TITLE
gutenbergsite uses bsky and masto (as does autocat3 template)

### DIFF
--- a/SearchPage.py
+++ b/SearchPage.py
@@ -72,7 +72,7 @@ class BookSearchPage (SearchPage):
             cat.subtitle = _("Like and follow to see our new books in your feed.")
             cat.url = 'https://mastodon.social/@gutenberg_new'
             cat.class_ += 'navlink grayed'
-            cat.icon = 'mastodon'
+            cat.icon = 'masto'
             cat.order = 5
             os.entries.insert (0, cat)
 
@@ -81,7 +81,7 @@ class BookSearchPage (SearchPage):
             cat.subtitle = _("Boost and follow to see our new books in your feed.")
             cat.url = 'https://bsky.app/profile/new.gutenberg.org'
             cat.class_ += 'navlink grayed'
-            cat.icon = 'bluesky'
+            cat.icon = 'bsky'
             cat.order = 5
             os.entries.insert (0, cat)
 


### PR DESCRIPTION
we need a PR for Autocat3 whichever classnames we use; this way we fix it correctly