### PR TITLE
Update header logo

### DIFF
--- a/templates/menu.html
+++ b/templates/menu.html
@@ -8,7 +8,7 @@
     </a>
 
     <a id="main_logo" href="/" class="no-hover">
-      <img src="/gutenberg/pg-logo-129x80.png" alt="Project Gutenberg" draggable="false" />
+      <img src="/gutenberg/pg-logo-new.jpg" alt="Project Gutenberg" draggable="false" />
     </a>
   </div>
 


### PR DESCRIPTION
Link to high-resolution version of the current logo (pg-logo-new.jpg).

https://github.com/gutenbergtools/gutenbergsite/pull/266 needs to happen first because that includes the actual new file.