### PR TITLE
fixes 2 A11y errors on bibrec page

### DIFF
--- a/BibrecPage.py
+++ b/BibrecPage.py
@@ -23,6 +23,17 @@ from i18n_tool import ungettext as __
 import BaseSearcher
 import Page
 
+SUMMARY_MARKERS = {
+    "This is an automatically generated summary",
+    "This summary is from Wikipedia",
+    "Summary by Project Gutenberg staff",
+    }
+
+def is_a_summary(text):
+    for summary_marker in SUMMARY_MARKERS:
+        if summary_marker in text:
+            return True
+    return False
 
 class BibrecPage (Page.Page):
     """ Implements the bibrec page. """
@@ -39,7 +50,7 @@ class BibrecPage (Page.Page):
 
     def get_book_summary(self, dc, book_id):
         for marc in dc.marcs:
-            if marc.code == '520' and "This is an automatically generated summary" in marc.text:
+            if marc.code == '520' and is_a_summary(marc.text):
                 return self.split_summary(marc.text)
         return None, None
 

--- a/templates/bibrec.html
+++ b/templates/bibrec.html
@@ -412,9 +412,7 @@ Gutenberg metadata much faster than by scraping.
 		      <span itemprop="price" content="$0.00">
 		        <em>Project Gutenberg eBooks are always free!</em>
 		      </span>
-		      <span itemprop="availability" content="In Stock" >
-		        <a href="http://schema.org/InStock"></a>
-		      </span>
+		      <link itemprop="availability" href="http://schema.org/InStock" />		      
               </td>
             </tr>
 

--- a/templates/bibrec.html
+++ b/templates/bibrec.html
@@ -169,19 +169,21 @@ Gutenberg metadata much faster than by scraping.
 				<span class="readmore-container">
 					<!-- Always visible content -->
 					${Markup(gg.insert_breaks(os.initial_summary, self_closing=False))}
-					<!-- Hidden checkbox to control the toggle -->
-					<input type="checkbox" id="toggle" class="toggle" style="display:none;" />
-					<!-- Clickable label to show more -->
-					<!-- The extra text that is initially hidden -->
-					<span class="toggle-content">
-					  ${Markup(gg.insert_breaks(os.remaining_summary, self_closing=False))}
+					<span py:if="os.remaining_summary" >
+                        <!-- Hidden checkbox to control the toggle -->
+                        <input type="checkbox" id="toggle" class="toggle" style="display:none;" />
+                        <!-- Clickable label to show more -->
+                        <!-- The extra text that is initially hidden -->
+                        <span class="toggle-content">
+                          ${Markup(gg.insert_breaks(os.remaining_summary, self_closing=False))}
+                        </span>
+                        <!-- Clickable label to show more/less -->
+                        <label for="toggle" >
+                            <span class="readmoredots">...  </span>
+                            <span class="readmore">Read More</span>
+                            <span class="showless">Show Less</span>					 
+                        </label>
 					</span>
-					<!-- Clickable label to show more/less -->
-					<label for="toggle" >
-						<span class="readmoredots">...  </span>
-						<span class="readmore">Read More</span>
-						<span class="showless">Show Less</span>					 
-					</label>
 				</span>
 				</div>
 			</py:if>

--- a/templates/bibrec.html
+++ b/templates/bibrec.html
@@ -172,15 +172,16 @@ Gutenberg metadata much faster than by scraping.
 					<!-- Hidden checkbox to control the toggle -->
 					<input type="checkbox" id="toggle" class="toggle" style="display:none;" />
 					<!-- Clickable label to show more -->
-					<label for="toggle" class="readmore">
-						... <span id="read_more"> Read More</span>
-					</label>
 					<!-- The extra text that is initially hidden -->
 					<span class="toggle-content">
 					  ${Markup(gg.insert_breaks(os.remaining_summary, self_closing=False))}
 					</span>
-					<!-- Clickable label to show less -->
-					<label for="toggle" class="showless"> Show Less</label>
+					<!-- Clickable label to show more/less -->
+					<label for="toggle" >
+						<span class="readmoredots">...  </span>
+						<span class="readmore">Read More</span>
+						<span class="showless">Show Less</span>					 
+					</label>
 				</span>
 				</div>
 			</py:if>

--- a/templates/site-layout.html
+++ b/templates/site-layout.html
@@ -17,7 +17,7 @@
       .page_content a.subtle_link:hover {color:#003366}
     </style>
 
-    <link rel="stylesheet" type="text/css" href="/gutenberg/gutenberg-globals.css"/>
+    <link rel="stylesheet" type="text/css" href="/gutenberg/gutenberg-globals.css?v=1"/>
 
     <!--! IE8 does not recognize application/javascript -->
     <script>//<![CDATA[


### PR DESCRIPTION
- fix microdata syntax
- us a single label for the checkbox that toggles the summary
- don't have checkbox  or toggle buttons if there's not more summary to show.
- add handling for summary markers indicating wikipedia summary and staff-written

these should result in zero errors in WAVE