### PR TITLE
Bibrec UX Update

### DIFF
--- a/BibrecPage.py
+++ b/BibrecPage.py
@@ -141,6 +141,8 @@ class BibrecPage (Page.Page):
             for bookshelf in dc.bookshelves:
                 cat = BaseSearcher.Cat ()
                 shelf_name = bookshelf.bookshelf
+                # "Browsing: " is an internal DB marker for Main Category bookshelves, not part of the display name.
+                # We strip it here until gutenbergtools/pgdb#12 fixes this at the data layer.
                 if shelf_name.startswith('Browsing: '):
                     shelf_name = shelf_name[len('Browsing: '):]
                 cat.title = shelf_name

--- a/BibrecPage.py
+++ b/BibrecPage.py
@@ -130,7 +130,6 @@ class BibrecPage (Page.Page):
 
         if os.format == 'html':
             cat = BaseSearcher.Cat ()
-            cat.header = _('Find Similar Books')
             cat.title = _('Readers also downloaded')
             cat.rel = 'related'
             cat.url = os.url ('also', id = os.id)

--- a/BibrecPage.py
+++ b/BibrecPage.py
@@ -74,12 +74,20 @@ class BibrecPage (Page.Page):
         dc.extra_info = None
         dc.url = None
         os.read_url = None
+        os.html_read_url = None
+        os.epub3_file = None
         for file_ in dc.files:
             # note that generated zip files don't get the "generated" bit or filetype set
             if not file_.generated and file_.filetype:
                 dc.update_date = max(dc.update_date, file_.modified.date())
             if os.read_url == None and file_.filetype:
                 os.read_url = f'/{file_.filename}'
+            if os.html_read_url is None and file_.filetype in ('html', 'html.images', 'html.noimages'):
+                os.html_read_url = f'/{file_.filename}'
+            if file_.filetype and file_.filetype.startswith('epub3'):
+                # prefer the .images version when both are present
+                if os.epub3_file is None or file_.filetype == 'epub3.images':
+                    os.epub3_file = file_
 
         dc.translate ()
         dc.header = gg.cut_at_newline (dc.title)
@@ -122,8 +130,8 @@ class BibrecPage (Page.Page):
 
         if os.format == 'html':
             cat = BaseSearcher.Cat ()
-            cat.header = _('Similar Books')
-            cat.title = _('Readers also downloaded…')
+            cat.header = _('Find Similar Books')
+            cat.title = _('Readers also downloaded')
             cat.rel = 'related'
             cat.url = os.url ('also', id = os.id)
             cat.class_ += 'navlink grayed noprint'
@@ -133,7 +141,10 @@ class BibrecPage (Page.Page):
 
             for bookshelf in dc.bookshelves:
                 cat = BaseSearcher.Cat ()
-                cat.title = _('In {bookshelf}').format (bookshelf = bookshelf.bookshelf)
+                shelf_name = bookshelf.bookshelf
+                if shelf_name.startswith('Browsing: '):
+                    shelf_name = shelf_name[len('Browsing: '):]
+                cat.title = shelf_name
                 cat.rel = 'related'
                 cat.url = os.url ('bookshelf', id = bookshelf.id)
                 cat.class_ += 'navlink grayed'

--- a/HTMLFormatter.py
+++ b/HTMLFormatter.py
@@ -166,6 +166,8 @@ class HTMLFormatter (XMLishFormatter):
                 file_.encoding = None
             if file_.encoding:
                 file_.hr_filetype += ' ' + file_.encoding.upper ()
+            if filetype.startswith ('txt'):
+                file_.hr_filetype = 'Plain Text (accessible)'
             if filetype.startswith ('html') and file_.compression == 'none':
                 if htmlcount > 0:
                     file_.hidden = True

--- a/HTMLFormatter.py
+++ b/HTMLFormatter.py
@@ -167,7 +167,7 @@ class HTMLFormatter (XMLishFormatter):
             if file_.encoding:
                 file_.hr_filetype += ' ' + file_.encoding.upper ()
             if filetype.startswith ('txt'):
-                file_.hr_filetype = 'Plain text (accessible)'
+                file_.hr_filetype = 'Plain Text (accessible)'
             if filetype.startswith ('html') and file_.compression == 'none':
                 if htmlcount > 0:
                     file_.hidden = True

--- a/HTMLFormatter.py
+++ b/HTMLFormatter.py
@@ -167,7 +167,7 @@ class HTMLFormatter (XMLishFormatter):
             if file_.encoding:
                 file_.hr_filetype += ' ' + file_.encoding.upper ()
             if filetype.startswith ('txt'):
-                file_.hr_filetype = 'Plain Text (accessible)'
+                file_.hr_filetype = 'Plain text (accessible)'
             if filetype.startswith ('html') and file_.compression == 'none':
                 if htmlcount > 0:
                     file_.hidden = True

--- a/templates/bibrec.html
+++ b/templates/bibrec.html
@@ -49,6 +49,30 @@ Gutenberg metadata much faster than by scraping.
        title="${explain (topic)}"><span class="icon icon_help noprint" /></a>
   </py:def>
 
+  <py:def function="cloud_actions(file_)">
+    <a py:if="file_.dropbox_url" href="${file_.dropbox_url}"
+       title="Send to Dropbox." rel="nofollow"><span class="icon icon_dropbox" /></a>
+    <a py:if="file_.gdrive_url" href="${file_.gdrive_url}"
+       title="Send to Google Drive." rel="nofollow"><span class="icon icon_gdrive" /></a>
+    <a py:if="file_.msdrive_url" href="${file_.msdrive_url}"
+       title="Send to OneDrive." rel="nofollow"><span class="icon icon_msdrive" /></a>
+  </py:def>
+
+  <py:def function="format_row(file_)">
+    <div class="other-format-row" about="${file_.url}" typeof="pgterms:file">
+      <div class="other-format-info">
+        <a class="other-format-link"
+           href="/${file_.filename}"
+           type="${file_.mediatypes[-1]}"
+           title="Download"
+           property="dcterms:format"
+           content="${file_.mediatypes[-1]}"
+           datatype="dcterms:IMT">${file_.hr_filetype}</a>
+      </div>
+      <div class="other-format-actions noprint">${cloud_actions(file_)}</div>
+    </div>
+  </py:def>
+
 	<script type="text/javascript">//<![CDATA[
 		var noprint_display_styles = [];
 		var noprint_elements = document.getElementsByClassName("noprint");
@@ -96,6 +120,7 @@ Gutenberg metadata much faster than by scraping.
     <xi:include href="menu.html" />
     <div class="page_content" id="content" itemscope="itemscope" itemtype="http://schema.org/Book" i18n:comment="On the 'bibrec' page.">
 
+      <!-- ============ SECTION: Breadcrumbs ============ -->
       <div class="breadcrumbs noprint">
 	<ul itemscope="itemscope" itemtype="https://schema.org/BreadcrumbList">
 	  <py:for each="n, bc in enumerate (os.breadcrumbs)">
@@ -107,7 +132,7 @@ Gutenberg metadata much faster than by scraping.
 	</ul>
       </div>
 
-	<!-- book title -->
+	<!-- ============ SECTION: Book title ============ -->
 	<h1 itemprop="name" id="book_title">${os.title}</h1>
 
 
@@ -115,6 +140,7 @@ Gutenberg metadata much faster than by scraping.
         <div property="dcterms:publisher" itemprop="publisher" content="Project Gutenberg" />
         <div itemprop="bookFormat" content="EBook" />
 
+	<!-- ============ SECTION: Cover / social / QR sidebar ============ -->
 	<div id="cover-social-wrapper">
 
 	  <div py:if="os.cover_image_url" id="cover">
@@ -159,11 +185,12 @@ Gutenberg metadata much faster than by scraping.
 	  </div>
 	</div>
 
+	<!-- ============ SECTION: Tabs wrapper / tabs ============ -->
 	<div id="tabs-wrapper">
 	<div id="tabs">
         <div id="download" i18n:comment="On the 'Download' tab of the 'bibrec' page.">
 
-			<!-- Display the summary with toggling functionality -->
+			<!-- ============ SECTION: Summary (isolated from bottom about-table by skip rule below at line ~326) ============ -->
 			<py:if test="os.initial_summary">
 				<div class="summary-text-container">
 				<span class="readmore-container">
@@ -189,87 +216,82 @@ Gutenberg metadata much faster than by scraping.
 			</py:if>
 
 
+            <!-- ============ SECTION: Read Online Now button (isolated from download table) ============ -->
+            <py:if test="os.html_read_url">
+              <div class="read-online-wrapper">
+                <a class="read-online-button" href="${os.html_read_url}" title="Read this book online now">
+                  Read Online Now!
+                </a>
+              </div>
+            </py:if>
+
+            <!-- ============ SECTION: Download section (card wrapper) ============ -->
             <py:for each="e in os.entries">
               <py:if test="isinstance(e, bs.DC)">
-            <div about="[ebook:$e.project_gutenberg_id]" rel="dcterms:hasFormat" >
+              <?python
+                other_files = [f for f in e.files
+                               if not f.hidden
+                               and f.filetype not in ('html', 'html.images', 'html.noimages')
+                               and not (f.filetype and f.filetype.startswith('epub3'))]
+              ?>
+              <py:if test="os.epub3_file or other_files or e.base_dir">
+            <div class="download-section" about="[ebook:$e.project_gutenberg_id]" rel="dcterms:hasFormat" >
 
-              <h2 id="download_options_header">Read or download for free </h2>
-			  
-			  <p id="reading_help_hint">For an overview of the different reading options, see our <a href="/help/reading_options.html" title="Not sure how to start reading? Click here!">Reading Guide</a></p>
+              <h2 id="download_options_header">Download for free</h2>
+
+			  <p py:if="os.epub3_file" id="reading_help_hint">For e-readers and reading apps<span class="reading-help-extra"> — Kindle, Kobo, Apple Books, Calibre &amp; more</span></p>
+
+              <!-- ============ SECTION: Featured EPUB3 (recommended) ============ -->
+              <py:if test="os.epub3_file">
+                <div class="featured-format">
+                  <div class="featured-format-row">
+                    <a class="featured-format-link" href="/${os.epub3_file.filename}" title="Download EPUB3">
+                      <span class="featured-format-name">EPUB3</span>
+                      <span class="featured-format-recommended">★ Recommended<span class="recommended-extra"> for most devices</span><span class="recommended-bang">!</span></span>
+                    </a>
+                    <div class="featured-format-actions noprint">${cloud_actions(os.epub3_file)}</div>
+                  </div>
+                  <div class="featured-format-tips">
+                    <div><strong>Kindle</strong> → Use <a href="/help/reading_options.html#kindle">Send-to-Kindle</a> after downloading</div>
+                    <div><strong>Kobo, Nook etc</strong> → Transfer via USB after downloading</div>
+                    <div><strong>Phone, tablet or computer</strong> → Open in reading app</div>
+                    <div><strong>More Help</strong> → see our <a class="full-reading-guide-link" href="/help/reading_options.html">Reading Guide</a></div>
+                  </div>
+                </div>
+              </py:if>
 				
-              <table class="files" id="download_options_table">
-                <colgroup>
-                  <col class="narrow" />
-                  <col />
-                  <col />
-                  <col />
-                  <col class="narrow noprint" />
-                  <col class="narrow noprint" />
-                  <col class="narrow noprint" />
-                </colgroup>
+              <py:if test="other_files or e.base_dir">
+                <!-- ============ SECTION: Other formats — collapsed disclosure (EPUB3 case) ============ -->
+                <details py:if="os.epub3_file" class="other-formats">
+                  <summary class="other-formats-summary">Other formats &amp; older devices</summary>
+                  <div class="other-formats-list">
+                    <py:for each="file_ in other_files">${format_row(file_)}</py:for>
+                    <p py:if="e.base_dir" class="other-formats-more">
+                      <span class="small">There may be
+                        <a class="subtle_link" rel="nofollow" href="${e.base_dir}">more files</a>
+                        related to this item.</span>
+                    </p>
+                  </div>
+                </details>
 
-                <tr>
-                  <td />
-                  <th> Reading Options </th>
-                  <th class="noscreen">Url</th>
-                  <th i18n:comment="Size of a file." class="right">Size</th>
-                  <py:choose test="help('Dropbox')">
-                    <td py:when="" class="noprint" />
-                    <th py:otherwise="" class="noprint"><span>${help('Dropbox')}</span></th>
-                  </py:choose>
-                  <py:choose test="help('Google Drive')">
-                    <td py:when="" class="noprint" />
-                    <th py:otherwise="" class="noprint"><span>${help('Google Drive')}</span></th>
-                  </py:choose>
-                  <py:choose test="help('OneDrive')">
-                    <td py:when="" class="noprint" />
-                    <th py:otherwise="" class="noprint"><span>${help('OneDrive')}</span></th>
-                  </py:choose>
-                </tr>
-
-                <tr py:for="i, file_ in enumerate(e.files)"
-                py:if="not file_.hidden"
-                class="${i%2 and 'odd' or 'even'}"
-                about="${file_.url}" typeof="pgterms:file">
-                  <td><span class="icon icon_${e.icon}" /></td>
-                  <td property="dcterms:format" content="${file_.mediatypes[-1]}" datatype="dcterms:IMT"
-                  class="unpadded icon_save"
-                  ><a href="/${file_.filename}" type="${file_.mediatypes[-1]}"
-                      class="link ${'read_html' if file_.filetype and file_.filetype.startswith('html') else ''}"
-                      title="${'Read online' if file_.filetype and file_.filetype.startswith('html') else 'Download'}"
-                      >${file_.hr_filetype}</a></td>
-                  <td class="noscreen">${file_.url}</td>
-                  <td  class="right"
-                   property="dcterms:extent" content="${file_.extent}">${file_.hr_extent}</td>
-                  <td class="noprint">
-                <a py:if="file_.dropbox_url"
-                   href="${file_.dropbox_url}"
-                   title="Send to Dropbox." rel="nofollow"><span class="icon icon_dropbox" /></a>
-                  </td>
-                  <td class="noprint">
-                <a py:if="file_.gdrive_url"
-                   href="${file_.gdrive_url}"
-                   title="Send to Google Drive." rel="nofollow"><span class="icon icon_gdrive" /></a>
-                  </td>
-                  <td class="noprint">
-                <a py:if="file_.msdrive_url"
-                   href="${file_.msdrive_url}"
-                   title="Send to OneDrive." rel="nofollow"><span class="icon icon_msdrive" /></a>
-                  </td>
-                </tr>
-                <tr py:if="e.base_dir"
-                class="${i%2 and 'odd' or 'even'}">
-                  <td><span class="icon icon_folder" /></td>
-                    <td colspan='5'><span class="small">
-                  There may be <a class="subtle_link" rel="nofollow" href="${e.base_dir}" >more files</a> related to this item.</span></td>
-                </tr>
-              </table>
+                <!-- ============ SECTION: Available formats — flat list (no-EPUB3 case) ============ -->
+                <div py:if="not os.epub3_file" class="other-formats-list other-formats-list--flat">
+                  <py:for each="file_ in other_files">${format_row(file_)}</py:for>
+                  <p py:if="e.base_dir" class="other-formats-more">
+                    <span class="small">There may be
+                      <a class="subtle_link" rel="nofollow" href="${e.base_dir}">more files</a>
+                      related to this item.</span>
+                  </p>
+                </div>
+              </py:if>
             </div>
+              </py:if>
               </py:if>
             </py:for>
 
           </div> <!-- download -->
 
+          <!-- ============ SECTION: Similar books / more_stuff ============ -->
           <div id="more_stuff">
             <py:for each="n, e in enumerate (os.entries)">
           <py:if test="isinstance (e, bs.Cat) and e.rel not in ('start', )">
@@ -286,9 +308,6 @@ Gutenberg metadata much faster than by scraping.
                  charset="${e.charset}"
                  accesskey="${str (n % 10)}"
                  class="similar-books-link">
-                <span class="cell leftcell">
-              <span class="icon icon_${e.icon}" />
-                </span>
                 <span class="cell content">
               <span class="title">${e.title}</span>
               <span py:if="e.subtitle" class="subtitle">${e.subtitle}</span>
@@ -300,6 +319,7 @@ Gutenberg metadata much faster than by scraping.
           </py:if>
             </py:for>
           </div> <!-- more stuff -->
+	  <!-- ============ SECTION: About this eBook (bibrec table) ============ -->
 	  <div id="bibrec" i18n:comment="On the 'bibrec' tab of the 'bibrec' page.">
 	    <py:for each="e in os.entries">
 	      <py:if test="isinstance (e, bs.DC)">
@@ -307,7 +327,7 @@ Gutenberg metadata much faster than by scraping.
 		  
 		<div typeof="pgterms:ebook" about="[ebook:$e.project_gutenberg_id]">
 
-		  <h2 id="about_book_header">About this eBook <span>${help (_('Table: Bibliographic Record'))}</span></h2>
+		  <h2 id="about_book_header">About this eBook</h2>
 
 		  <table class="bibrec" id="about_book_table">
 		    <colgroup>
@@ -395,12 +415,12 @@ Gutenberg metadata much faster than by scraping.
 
 		    <tr property="dcterms:modified" datatype="xsd:date" content="${e.xsd_release_date_time}"
 		        py:if="e.update_date > e.release_date">
-		      <th>Most Recently Updated</th>
+		      <th>Last Update</th>
 		      <td itemprop="dateModified">${e.hr_update_date}</td>
 		    </tr>
 
 		    <tr>
-		      <th>Copyright Status</th>
+		      <th>Copyright</th>
 		      <td property="dcterms:rights">${e.rights}</td>
 		    </tr>
 
@@ -408,16 +428,6 @@ Gutenberg metadata much faster than by scraping.
 		      <th>Downloads</th>
 		      <td itemprop="interactionCount" i18n:msg="count">${e.downloads} downloads in the last 30 days.</td>
 		    </tr>
-
-		    <tr itemprop="offers" itemscope="itemscope" itemtype="http://schema.org/Offer">
-		      <td colspan="2">
-		      <span itemprop="priceCurrency" content="USD" />
-		      <span itemprop="price" content="$0.00">
-		        <em>Project Gutenberg eBooks are always free!</em>
-		      </span>
-		      <link itemprop="availability" href="http://schema.org/InStock" />		      
-              </td>
-            </tr>
 
 		  </table>
 

--- a/templates/bibrec.html
+++ b/templates/bibrec.html
@@ -220,7 +220,7 @@ Gutenberg metadata much faster than by scraping.
             <py:if test="os.html_read_url">
               <div class="read-online-wrapper">
                 <a class="read-online-button" href="${os.html_read_url}" title="Read this book online now">
-                  Read Online Now!
+                  Read Online Now
                 </a>
               </div>
             </py:if>
@@ -237,7 +237,7 @@ Gutenberg metadata much faster than by scraping.
               <py:if test="os.epub3_file or other_files or e.base_dir">
             <div class="download-section" about="[ebook:$e.project_gutenberg_id]" rel="dcterms:hasFormat" >
 
-              <h2 id="download_options_header">Download</h2>
+              <h2 id="download_options_header">Download for free</h2>
 
 			  <p py:if="os.epub3_file" id="reading_help_hint">For e-readers and reading apps<span class="reading-help-extra"> — Kindle, Kobo, Apple Books, Calibre etc.</span></p>
 
@@ -293,22 +293,18 @@ Gutenberg metadata much faster than by scraping.
 
           <!-- ============ SECTION: Similar books / more_stuff ============ -->
           <div id="more_stuff">
-            <py:for each="n, e in enumerate (os.entries)">
-          <py:if test="isinstance (e, bs.Cat) and e.rel not in ('start', )">
-            <py:if test="e.header and old_header != e.header">
-              <h2 class="header middle_section_header">${e.header}</h2>
-            </py:if>
-            <?python old_header = e.header ?>
-
-            <a rel="nofollow"
-               href="${e.url}"
-               accesskey="${str (n % 10)}"
-               class="${'similar-books-lead' if e.icon == 'suggestion' else 'similar-books-tag'}">
-              <span class="title">${e.title}</span>
-              <span py:if="e.subtitle" class="subtitle">${e.subtitle}</span>
-            </a>
-          </py:if>
-            </py:for>
+            <div class="similar-books-tags">
+              <py:for each="n, e in enumerate (os.entries)">
+                <py:if test="isinstance (e, bs.Cat) and e.icon == 'suggestion'">
+                  <a rel="nofollow" href="${e.url}" accesskey="${str (n % 10)}" class="similar-books-tag">${e.title}</a>
+                </py:if>
+              </py:for>
+              <py:for each="n, e in enumerate (os.entries)">
+                <py:if test="isinstance (e, bs.Cat) and e.icon == 'bookshelf'">
+                  <a rel="nofollow" href="${e.url}" accesskey="${str (n % 10)}" class="similar-books-tag">${e.title}</a>
+                </py:if>
+              </py:for>
+            </div>
           </div> <!-- more stuff -->
 	  <!-- ============ SECTION: About this eBook (bibrec table) ============ -->
 	  <div id="bibrec" i18n:comment="On the 'bibrec' tab of the 'bibrec' page.">

--- a/templates/bibrec.html
+++ b/templates/bibrec.html
@@ -237,9 +237,9 @@ Gutenberg metadata much faster than by scraping.
               <py:if test="os.epub3_file or other_files or e.base_dir">
             <div class="download-section" about="[ebook:$e.project_gutenberg_id]" rel="dcterms:hasFormat" >
 
-              <h2 id="download_options_header">Download for free</h2>
+              <h2 id="download_options_header">Download</h2>
 
-			  <p py:if="os.epub3_file" id="reading_help_hint">For e-readers and reading apps<span class="reading-help-extra"> — Kindle, Kobo, Apple Books, Calibre &amp; more</span></p>
+			  <p py:if="os.epub3_file" id="reading_help_hint">For e-readers and reading apps<span class="reading-help-extra"> — Kindle, Kobo, Apple Books, Calibre etc.</span></p>
 
               <!-- ============ SECTION: Featured EPUB3 (recommended) ============ -->
               <py:if test="os.epub3_file">
@@ -252,10 +252,10 @@ Gutenberg metadata much faster than by scraping.
                     <div class="featured-format-actions noprint">${cloud_actions(os.epub3_file)}</div>
                   </div>
                   <div class="featured-format-tips">
-                    <div><strong>Kindle</strong> → Use <a href="/help/reading_options.html#kindle">Send-to-Kindle</a> after downloading</div>
-                    <div><strong>Kobo, Nook etc</strong> → Transfer via USB after downloading</div>
-                    <div><strong>Phone, tablet or computer</strong> → Open in reading app</div>
-                    <div><strong>More Help</strong> → see our <a class="full-reading-guide-link" href="/help/reading_options.html">Reading Guide</a></div>
+                    <div><strong>Kindle</strong> → Use <a href="/help/reading_options.html#kindle">Send-to-Kindle</a></div>
+                    <div><strong>Kobo, Nook etc</strong> → <a href="/help/reading_options.html#kobo-nook-etc">Transfer via USB</a></div>
+                    <div><strong>Phone, tablet or computer</strong> → Open in a reading app</div>
+                    <div><strong>Overview</strong> → see our <a class="full-reading-guide-link" href="/help/reading_options.html">Reading Guide</a></div>
                   </div>
                 </div>
               </py:if>

--- a/templates/bibrec.html
+++ b/templates/bibrec.html
@@ -300,22 +300,13 @@ Gutenberg metadata much faster than by scraping.
             </py:if>
             <?python old_header = e.header ?>
 
-            <div class="${e.class_}">
-			  <!-- Similar Books Links -->
-              <a rel="nofollow"
-                 href="${e.url}"
-                 type="${e.type}"
-                 charset="${e.charset}"
-                 accesskey="${str (n % 10)}"
-                 class="similar-books-link">
-                <span class="cell content">
+            <a rel="nofollow"
+               href="${e.url}"
+               accesskey="${str (n % 10)}"
+               class="${'similar-books-lead' if e.icon == 'suggestion' else 'similar-books-tag'}">
               <span class="title">${e.title}</span>
               <span py:if="e.subtitle" class="subtitle">${e.subtitle}</span>
-              <span py:if="e.extra" class="extra">${e.extra}</span>
-                </span>
-                <span class="hstrut" />
-              </a>
-            </div>
+            </a>
           </py:if>
             </py:for>
           </div> <!-- more stuff -->

--- a/templates/bibrec.html
+++ b/templates/bibrec.html
@@ -28,7 +28,6 @@ Gutenberg metadata much faster than by scraping.
 
     os.description = "Free eBook digitized and proofread by volunteers."
 
-    old_header = os.entries[0].header # suppress first header as already in <h1>
     def help_page (s = ''):
         s = s.replace (' ', '_')
         return '%s#%s' % ('/help/bibliographic_record.html', s)
@@ -49,6 +48,7 @@ Gutenberg metadata much faster than by scraping.
        title="${explain (topic)}"><span class="icon icon_help noprint" /></a>
   </py:def>
 
+  <!-- Shared by the featured EPUB3 card and each row in the other-formats list. -->
   <py:def function="cloud_actions(file_)">
     <a py:if="file_.dropbox_url" href="${file_.dropbox_url}"
        title="Send to Dropbox." rel="nofollow"><span class="icon icon_dropbox" /></a>
@@ -58,6 +58,7 @@ Gutenberg metadata much faster than by scraping.
        title="Send to OneDrive." rel="nofollow"><span class="icon icon_msdrive" /></a>
   </py:def>
 
+  <!-- One row per non-featured download format. Reused by the EPUB3-present and no-EPUB3 layouts below. -->
   <py:def function="format_row(file_)">
     <div class="other-format-row" about="${file_.url}" typeof="pgterms:file">
       <div class="other-format-info">
@@ -69,7 +70,8 @@ Gutenberg metadata much faster than by scraping.
            content="${file_.mediatypes[-1]}"
            datatype="dcterms:IMT">${file_.hr_filetype}</a>
       </div>
-      <div class="other-format-actions noprint">${cloud_actions(file_)}</div>
+      <div py:if="file_.dropbox_url or file_.gdrive_url or file_.msdrive_url"
+           class="other-format-actions noprint">${cloud_actions(file_)}</div>
     </div>
   </py:def>
 
@@ -120,7 +122,6 @@ Gutenberg metadata much faster than by scraping.
     <xi:include href="menu.html" />
     <div class="page_content" id="content" itemscope="itemscope" itemtype="http://schema.org/Book" i18n:comment="On the 'bibrec' page.">
 
-      <!-- ============ SECTION: Breadcrumbs ============ -->
       <div class="breadcrumbs noprint">
 	<ul itemscope="itemscope" itemtype="https://schema.org/BreadcrumbList">
 	  <py:for each="n, bc in enumerate (os.breadcrumbs)">
@@ -132,7 +133,6 @@ Gutenberg metadata much faster than by scraping.
 	</ul>
       </div>
 
-	<!-- ============ SECTION: Book title ============ -->
 	<h1 itemprop="name" id="book_title">${os.title}</h1>
 
 
@@ -140,7 +140,6 @@ Gutenberg metadata much faster than by scraping.
         <div property="dcterms:publisher" itemprop="publisher" content="Project Gutenberg" />
         <div itemprop="bookFormat" content="EBook" />
 
-	<!-- ============ SECTION: Cover / social / QR sidebar ============ -->
 	<div id="cover-social-wrapper">
 
 	  <div py:if="os.cover_image_url" id="cover">
@@ -185,12 +184,11 @@ Gutenberg metadata much faster than by scraping.
 	  </div>
 	</div>
 
-	<!-- ============ SECTION: Tabs wrapper / tabs ============ -->
 	<div id="tabs-wrapper">
 	<div id="tabs">
         <div id="download" i18n:comment="On the 'Download' tab of the 'bibrec' page.">
 
-			<!-- ============ SECTION: Summary (isolated from bottom about-table by skip rule below at line ~326) ============ -->
+			<!-- Top-of-page summary. The about-table below filters out the auto-generated summary marc to avoid showing it twice. -->
 			<py:if test="os.initial_summary">
 				<div class="summary-text-container">
 				<span class="readmore-container">
@@ -216,7 +214,7 @@ Gutenberg metadata much faster than by scraping.
 			</py:if>
 
 
-            <!-- ============ SECTION: Read Online Now button (isolated from download table) ============ -->
+            <!-- Lifted out of the download table so it reads as a primary CTA, not a file format. -->
             <py:if test="os.html_read_url">
               <div class="read-online-wrapper">
                 <a class="read-online-button" href="${os.html_read_url}" title="Read this book online now">
@@ -225,73 +223,72 @@ Gutenberg metadata much faster than by scraping.
               </div>
             </py:if>
 
-            <!-- ============ SECTION: Download section (card wrapper) ============ -->
             <py:for each="e in os.entries">
               <py:if test="isinstance(e, bs.DC)">
-              <?python
-                other_files = [f for f in e.files
-                               if not f.hidden
-                               and f.filetype not in ('html', 'html.images', 'html.noimages')
-                               and not (f.filetype and f.filetype.startswith('epub3'))]
-              ?>
-              <py:if test="os.epub3_file or other_files or e.base_dir">
-            <div class="download-section" about="[ebook:$e.project_gutenberg_id]" rel="dcterms:hasFormat" >
+                <?python
+                  # Files surfaced under "Other formats". Excludes html (Read Online button) and epub3 (featured card).
+                  other_files = [f for f in e.files
+                                 if not f.hidden
+                                 and f.filetype not in ('html', 'html.images', 'html.noimages')
+                                 and not (f.filetype and f.filetype.startswith('epub3'))]
+                ?>
+                <py:if test="os.epub3_file or other_files or e.base_dir">
+                  <div class="download-section" about="[ebook:$e.project_gutenberg_id]" rel="dcterms:hasFormat">
 
-              <h2 id="download_options_header">Download for free</h2>
+                    <h2 id="download_options_header">Download for free</h2>
 
-			  <p py:if="os.epub3_file" id="reading_help_hint">For e-readers and reading apps<span class="reading-help-extra"> — Kindle, Kobo, Apple Books, Calibre etc.</span></p>
+                    <!-- The .reading-help-extra span hides at narrower viewports (≤960px) via CSS. -->
+                    <p py:if="os.epub3_file" id="reading_help_hint">For e-readers and reading apps<span class="reading-help-extra"> — Kindle, Kobo, Apple Books, Calibre etc.</span></p>
 
-              <!-- ============ SECTION: Featured EPUB3 (recommended) ============ -->
-              <py:if test="os.epub3_file">
-                <div class="featured-format">
-                  <div class="featured-format-row">
-                    <a class="featured-format-link" href="/${os.epub3_file.filename}" title="Download EPUB3">
-                      <span class="featured-format-name">EPUB3</span>
-                      <span class="featured-format-recommended">★ Recommended<span class="recommended-extra"> for most devices</span><span class="recommended-bang">!</span></span>
-                    </a>
-                    <div class="featured-format-actions noprint">${cloud_actions(os.epub3_file)}</div>
+                    <py:if test="os.epub3_file">
+                      <div class="featured-format">
+                        <div class="featured-format-row">
+                          <a class="featured-format-link" href="/${os.epub3_file.filename}" title="Download EPUB3">
+                            <span class="featured-format-name">EPUB3</span>
+                            <span class="featured-format-recommended">★ Recommended<span class="recommended-extra"> for most devices</span><span class="recommended-bang">!</span></span>
+                          </a>
+                          <div class="featured-format-actions noprint">${cloud_actions(os.epub3_file)}</div>
+                        </div>
+                        <div class="featured-format-tips">
+                          <div><strong>Kindle</strong> → Use <a href="/help/reading_options.html#kindle">Send-to-Kindle</a></div>
+                          <div><strong>Kobo, Nook etc</strong> → <a href="/help/reading_options.html#kobo-nook-etc">Transfer via USB</a></div>
+                          <div><strong>Phone, tablet or computer</strong> → Open in a reading app</div>
+                          <div><a class="full-reading-guide-link" href="/help/reading_options.html">Reading Guide</a></div>
+                        </div>
+                      </div>
+                    </py:if>
+
+                    <py:if test="other_files or e.base_dir">
+                      <!-- When EPUB3 is featured above, the rest collapses behind a disclosure. Otherwise we render a flat list (no featured card to demote them under). -->
+                      <details py:if="os.epub3_file" class="other-formats">
+                        <summary class="other-formats-summary">Other formats &amp; older devices</summary>
+                        <div class="other-formats-list">
+                          <py:for each="file_ in other_files">${format_row(file_)}</py:for>
+                          <p py:if="e.base_dir" class="other-formats-more">
+                            <span class="small">There may be
+                              <a class="subtle_link" rel="nofollow" href="${e.base_dir}">more files</a>
+                              related to this item.</span>
+                          </p>
+                        </div>
+                      </details>
+
+                      <div py:if="not os.epub3_file" class="other-formats-list other-formats-list--flat">
+                        <py:for each="file_ in other_files">${format_row(file_)}</py:for>
+                        <p py:if="e.base_dir" class="other-formats-more">
+                          <span class="small">There may be
+                            <a class="subtle_link" rel="nofollow" href="${e.base_dir}">more files</a>
+                            related to this item.</span>
+                        </p>
+                      </div>
+                    </py:if>
                   </div>
-                  <div class="featured-format-tips">
-                    <div><strong>Kindle</strong> → Use <a href="/help/reading_options.html#kindle">Send-to-Kindle</a></div>
-                    <div><strong>Kobo, Nook etc</strong> → <a href="/help/reading_options.html#kobo-nook-etc">Transfer via USB</a></div>
-                    <div><strong>Phone, tablet or computer</strong> → Open in a reading app</div>
-                    <div><strong>Overview</strong> → see our <a class="full-reading-guide-link" href="/help/reading_options.html">Reading Guide</a></div>
-                  </div>
-                </div>
-              </py:if>
-				
-              <py:if test="other_files or e.base_dir">
-                <!-- ============ SECTION: Other formats — collapsed disclosure (EPUB3 case) ============ -->
-                <details py:if="os.epub3_file" class="other-formats">
-                  <summary class="other-formats-summary">Other formats &amp; older devices</summary>
-                  <div class="other-formats-list">
-                    <py:for each="file_ in other_files">${format_row(file_)}</py:for>
-                    <p py:if="e.base_dir" class="other-formats-more">
-                      <span class="small">There may be
-                        <a class="subtle_link" rel="nofollow" href="${e.base_dir}">more files</a>
-                        related to this item.</span>
-                    </p>
-                  </div>
-                </details>
-
-                <!-- ============ SECTION: Available formats — flat list (no-EPUB3 case) ============ -->
-                <div py:if="not os.epub3_file" class="other-formats-list other-formats-list--flat">
-                  <py:for each="file_ in other_files">${format_row(file_)}</py:for>
-                  <p py:if="e.base_dir" class="other-formats-more">
-                    <span class="small">There may be
-                      <a class="subtle_link" rel="nofollow" href="${e.base_dir}">more files</a>
-                      related to this item.</span>
-                  </p>
-                </div>
-              </py:if>
-            </div>
-              </py:if>
+                </py:if>
               </py:if>
             </py:for>
 
           </div> <!-- download -->
 
-          <!-- ============ SECTION: Similar books / more_stuff ============ -->
+          <!-- Similar-books row. Two passes so "Readers also downloaded" (suggestion) always sorts first, regardless of os.entries order. -->
           <div id="more_stuff">
             <div class="similar-books-tags">
               <py:for each="n, e in enumerate (os.entries)">
@@ -305,8 +302,7 @@ Gutenberg metadata much faster than by scraping.
                 </py:if>
               </py:for>
             </div>
-          </div> <!-- more stuff -->
-	  <!-- ============ SECTION: About this eBook (bibrec table) ============ -->
+          </div>
 	  <div id="bibrec" i18n:comment="On the 'bibrec' tab of the 'bibrec' page.">
 	    <py:for each="e in os.entries">
 	      <py:if test="isinstance (e, bs.DC)">
@@ -417,6 +413,13 @@ Gutenberg metadata much faster than by scraping.
 		    </tr>
 
 		  </table>
+
+		  <!-- schema.org Offer microdata — meta/link tags are non-rendering, so this surfaces free / in-stock signals to crawlers without visible UI. -->
+		  <div itemprop="offers" itemscope="itemscope" itemtype="http://schema.org/Offer">
+		    <meta itemprop="priceCurrency" content="USD" />
+		    <meta itemprop="price" content="0.00" />
+		    <link itemprop="availability" href="http://schema.org/InStock" />
+		  </div>
 
 		</div>
 	      </py:if>

--- a/templates/bibrec.html
+++ b/templates/bibrec.html
@@ -143,7 +143,7 @@ Gutenberg metadata much faster than by scraping.
 	<div id="cover-social-wrapper">
 
 	  <div py:if="os.cover_image_url" id="cover">
-	    <a href="${os.read_url}" title="Read Now!">
+	    <a href="${os.read_url}" title="Read now!">
 	    <img class="cover-art"
 		 src="${os.cover_image_url}"
 		 title="Book Cover"
@@ -182,7 +182,7 @@ Gutenberg metadata much faster than by scraping.
 	  <div id="qr">
 	    <details class="qr-details">
 	      <summary>QR code</summary>
-	      <span class="qrcode qrcode-desktop" title="Scan QR Code for this page." />
+	      <span class="qrcode qrcode-desktop" title="Scan QR code for this page." />
 	    </details>
 	  </div>
 	</div>
@@ -208,8 +208,8 @@ Gutenberg metadata much faster than by scraping.
                         <!-- Clickable label to show more/less -->
                         <label for="toggle" >
                             <span class="readmoredots">...  </span>
-                            <span class="readmore">Read More</span>
-                            <span class="showless">Show Less</span>					 
+                            <span class="readmore">Read more</span>
+                            <span class="showless">Show less</span>					 
                         </label>
 					</span>
 				</span>
@@ -221,7 +221,7 @@ Gutenberg metadata much faster than by scraping.
             <py:if test="os.html_read_url">
               <div class="read-online-wrapper">
                 <a class="read-online-button" href="${os.html_read_url}" title="Read this book online now">
-                  Read Online Now
+                  Read online now
                 </a>
               </div>
             </py:if>
@@ -243,7 +243,7 @@ Gutenberg metadata much faster than by scraping.
                     <h2 id="download_options_header">Download for free</h2>
 
                     <!-- The .reading-help-extra span hides at narrower viewports (≤960px) via CSS. -->
-                    <p py:if="os.epub3_file" id="reading_help_hint">For e-readers and reading apps<span class="reading-help-extra"> — Kindle, Kobo, Apple Books, Calibre etc.</span></p>
+                    <p py:if="os.epub3_file" id="reading_help_hint">For your e-reader or reading app<span class="reading-help-extra"> — Kindle, Kobo, Apple Books, Calibre etc.</span></p>
 
                     <py:if test="os.epub3_file">
                       <div class="featured-format">
@@ -258,7 +258,7 @@ Gutenberg metadata much faster than by scraping.
                           <div><strong>Kindle</strong> → Use <a href="/help/reading_options.html#kindle">Send-to-Kindle</a></div>
                           <div><strong>Kobo, Nook etc</strong> → <a href="/help/reading_options.html#kobo-nook-etc">Transfer via USB</a></div>
                           <div><strong>Phone, tablet or computer</strong> → Open in a reading app</div>
-                          <div><a class="full-reading-guide-link" href="/help/reading_options.html">Reading Guide</a></div>
+                          <div><a class="full-reading-guide-link" href="/help/reading_options.html">Reading guide</a></div>
                         </div>
                       </div>
                     </py:if>
@@ -392,7 +392,7 @@ Gutenberg metadata much faster than by scraping.
 		    </tr>
 
 		    <tr>
-		      <th>EBook-No.</th>
+		      <th>eBook-No.</th>
 		      <td>${e.project_gutenberg_id}</td>
 		    </tr>
 

--- a/templates/bibrec.html
+++ b/templates/bibrec.html
@@ -180,7 +180,10 @@ Gutenberg metadata much faster than by scraping.
 	  </div>
 
 	  <div id="qr">
-	    <span class="qrcode qrcode-desktop" title="Scan QR Code for this page." />
+	    <details class="qr-details">
+	      <summary>QR code</summary>
+	      <span class="qrcode qrcode-desktop" title="Scan QR Code for this page." />
+	    </details>
 	  </div>
 	</div>
 
@@ -231,6 +234,8 @@ Gutenberg metadata much faster than by scraping.
                                  if not f.hidden
                                  and f.filetype not in ('html', 'html.images', 'html.noimages')
                                  and not (f.filetype and f.filetype.startswith('epub3'))]
+                  # Surface Plain Text at the top — accessibility-friendly default.
+                  other_files.sort(key=lambda f: 0 if (f.filetype or '').startswith('txt') else 1)
                 ?>
                 <py:if test="os.epub3_file or other_files or e.base_dir">
                   <div class="download-section" about="[ebook:$e.project_gutenberg_id]" rel="dcterms:hasFormat">
@@ -418,7 +423,7 @@ Gutenberg metadata much faster than by scraping.
 		    <meta itemprop="priceCurrency" content="USD" />
 		    <meta itemprop="price" content="0.00" />
 		    <link itemprop="availability" href="http://schema.org/InStock" />
-		    <em>Project Gutenberg eBooks are always free!</em>
+		    <p>Project Gutenberg eBooks are always free!</p>
 		  </div>
 
 		</div>

--- a/templates/bibrec.html
+++ b/templates/bibrec.html
@@ -65,7 +65,7 @@ Gutenberg metadata much faster than by scraping.
         <a class="other-format-link"
            href="/${file_.filename}"
            type="${file_.mediatypes[-1]}"
-           title="Download"
+           title="Download (${file_.hr_extent})"
            property="dcterms:format"
            content="${file_.mediatypes[-1]}"
            datatype="dcterms:IMT">${file_.hr_filetype}</a>
@@ -243,7 +243,7 @@ Gutenberg metadata much faster than by scraping.
                     <py:if test="os.epub3_file">
                       <div class="featured-format">
                         <div class="featured-format-row">
-                          <a class="featured-format-link" href="/${os.epub3_file.filename}" title="Download EPUB3">
+                          <a class="featured-format-link" href="/${os.epub3_file.filename}" title="Download EPUB3 (${os.epub3_file.hr_extent})">
                             <span class="featured-format-name">EPUB3</span>
                             <span class="featured-format-recommended">★ Recommended<span class="recommended-extra"> for most devices</span><span class="recommended-bang">!</span></span>
                           </a>
@@ -414,11 +414,11 @@ Gutenberg metadata much faster than by scraping.
 
 		  </table>
 
-		  <!-- schema.org Offer microdata — meta/link tags are non-rendering, so this surfaces free / in-stock signals to crawlers without visible UI. -->
-		  <div itemprop="offers" itemscope="itemscope" itemtype="http://schema.org/Offer">
+		  <div class="offer-note" itemprop="offers" itemscope="itemscope" itemtype="http://schema.org/Offer">
 		    <meta itemprop="priceCurrency" content="USD" />
 		    <meta itemprop="price" content="0.00" />
 		    <link itemprop="availability" href="http://schema.org/InStock" />
+		    <em>Project Gutenberg eBooks are always free!</em>
 		  </div>
 
 		</div>


### PR DESCRIPTION
Template + `BibrecPage.py` changes for Bibrec UX update. Companion to PR: https://github.com/gutenbergtools/gutenbergsite/pull/293

## UX Problems solved/addressed

- "Read Online Now" button prominently placed apart from Download options.
- EPUB3 clearly presented as the go-to option. Alternatives are still present but without being dominant.
-  Advice and links for how to get started reading Gberg books now active part of page (below EPUB3).
- "Similar Books" section converted into clean tag design. Much more usable.
- Face-lift for "About Ebook" table at bottom.

## Notes
- For books that don't have EPUB3 a simplified but robust design sets in.
- Some tags can get long but still look fine imo (or at least better than status quo). 
- done a good bunch of spot testing locally. no functional problems found. I suggest another thorough round of testing though when on dev just to be sure.
- tablet and mobile versions are solid.

## Technical

- Most of the work is in the template. The old download table got broken up into UI pieces the new design needs (Read-Online CTA, featured-format card etc) with a couple of small Genshi helpers.
- `BibrecPage.py` picked up some light functionality so the template doesn't have to do its own format-picking — the page now hands it the right HTML file and best EPUB3 file directly. Plus a few small copy/data tweaks along the way (cleaner bookshelf-name display, dropping a now-unused field).
- The new class names line up with the selectors in gutenbergsite PR #293

## See Screenshots below