### PR TITLE
Rename kf8 download option

### DIFF
--- a/HTMLFormatter.py
+++ b/HTMLFormatter.py
@@ -173,6 +173,8 @@ class HTMLFormatter (XMLishFormatter):
                         htmlcount += 1
             elif filetype == 'epub.images':
                 file_.hr_filetype = 'EPUB (older e-readers)'
+            elif filetype == 'kf8.images':
+                file_.hr_filetype = 'Kindles (kf8)'
             elif filetype == 'kindle.images':
                 file_.hr_filetype = 'Older Kindles'
             elif filetype == 'epub.noimages':


### PR DESCRIPTION
kf8 download option is currently shown as "Kindle" in the UI. That's misleading, since it's clearly not the right choice for most Kindle users. Change to "Older Kindles (kf8)".