### PR TITLE
Stable Version of OPDS2.0 Catalog

### DIFF
--- a/CherryPy.conf
+++ b/CherryPy.conf
@@ -21,6 +21,9 @@ pgport:     5432
 pgdatabase: 'gutenberg'
 pguser:     'postgres'
 
+# Hour of day (0-23) to refresh mv_books_dc materialized view.
+mv_refresh_hour: 17
+
 host:        'www.gutenberg.org'
 host_https:  1
 file_host:   'www.gutenberg.org'

--- a/CherryPyApp.py
+++ b/CherryPyApp.py
@@ -44,6 +44,7 @@ import MetricsPage
 import Sitemap
 import Formatters
 from errors import ErrorPage
+from OPDS2 import OPDSFeed, OPDS_MOUNT_CONFIG, _json_error_page
 
 import Timer
 
@@ -172,7 +173,8 @@ def main():
         cherrypy.engine, params=GutenbergDatabase.get_connection_params(cherrypy.config))
     cherrypy.engine.pool.subscribe()
 
-    plugins.Timer(cherrypy.engine).subscribe()
+    timer = plugins.Timer(cherrypy.engine)
+    timer.subscribe()
 
     cherrypy.log("Daemonizing", context='ENGINE', severity=logging.INFO)
 
@@ -333,6 +335,9 @@ def main():
                                   'tools.staticdir.dir': install_dir + "/gutenberg"}})
         app.merge({'/pics': {'tools.staticdir.on': True,
                              'tools.staticdir.dir': install_dir + "/pics"}})
+    # Mount OPDS feed at /opds
+    cherrypy.log("Mounting OPDS feed", context='ENGINE', severity=logging.INFO)
+    cherrypy.tree.mount(OPDSFeed(), '/opds', OPDS_MOUNT_CONFIG)
 
     return app
 

--- a/CherryPyApp.py
+++ b/CherryPyApp.py
@@ -44,7 +44,7 @@ import MetricsPage
 import Sitemap
 import Formatters
 from errors import ErrorPage
-from OPDS2 import OPDSFeed, OPDS_MOUNT_CONFIG, _json_error_page
+from OPDS2 import OPDSFeed, OPDS_MOUNT_CONFIG
 
 import Timer
 
@@ -321,6 +321,13 @@ def main():
         d.connect('msdrive_callback', r'/ebooks/send/msdrive/',
                    controller=msdrive)
 
+    # OPDS 2.0
+    opds = OPDSFeed()
+    d.connect('opds', r'/opds/', controller=opds, action='index')
+    for action in ('search', 'bookshelves', 'bookshelf_groups', 'loccs',
+                   'subjects', 'also', 'publications'):
+        d.connect('opds_' + action, '/opds/' + action, controller=opds, action=action)
+
     # start http server
     #
 
@@ -335,9 +342,8 @@ def main():
                                   'tools.staticdir.dir': install_dir + "/gutenberg"}})
         app.merge({'/pics': {'tools.staticdir.on': True,
                              'tools.staticdir.dir': install_dir + "/pics"}})
-    # Mount OPDS feed at /opds
-    cherrypy.log("Mounting OPDS feed", context='ENGINE', severity=logging.INFO)
-    cherrypy.tree.mount(OPDSFeed(), '/opds', OPDS_MOUNT_CONFIG)
+
+    app.merge(OPDS_MOUNT_CONFIG)
 
     return app
 

--- a/OPDS2.py
+++ b/OPDS2.py
@@ -108,13 +108,16 @@ OPDS_GZIP_MIME_TYPES = [
     "application/opds-publication+json",
 ]
 
+# Path config for the main app (merge as-is).
 OPDS_MOUNT_CONFIG = {
-    "/": {
+    "/opds": {
         "tools.response_headers.on": True,
         "tools.json_in.on": True,
         "tools.json_out.on": True,
         "tools.gzip.on": True,
         "tools.gzip.mime_types": OPDS_GZIP_MIME_TYPES,
+        "tools.I18nTool.on": False,
+        "tools.sessions.on": False,
         "error_page.404": _json_error_page,
         "error_page.500": _json_error_page,
         "error_page.default": _json_error_page,
@@ -542,7 +545,7 @@ class OPDSFeed:
 
     # Index
     @cherrypy.expose
-    def index(self):
+    def index(self, **_):
         """Root catalog."""
         return self._cache_feed(
             "index", self._build_index, store=lambda feed: bool(feed.get("groups"))
@@ -660,6 +663,7 @@ class OPDSFeed:
         lang: str = "",
         sort: str = "",
         sort_order: str = "",
+        **_,
     ):
         """Bookshelf navigation."""
         page, limit = _paginate(page, limit)
@@ -830,7 +834,7 @@ class OPDSFeed:
         )
 
     @cherrypy.expose
-    def bookshelf_groups(self, category: Optional[str] = None):
+    def bookshelf_groups(self, category: Optional[str] = None, **_):
         """Homepage-style category browse with per-shelf preview groups."""
         if category is None:
             return self._error_feed(
@@ -913,6 +917,7 @@ class OPDSFeed:
         lang: str = "",
         sort: str = "",
         sort_order: str = "",
+        **_,
     ):
         """LoCC hierarchical navigation."""
         parent = (parent or "").strip().upper()
@@ -1068,6 +1073,7 @@ class OPDSFeed:
         lang: str = "",
         sort: str = "",
         sort_order: str = "",
+        **_,
     ):
         """Subject navigation."""
         page, limit = _paginate(page, limit)
@@ -1156,7 +1162,7 @@ class OPDSFeed:
     # Also downloaded
 
     @cherrypy.expose
-    def also(self, id: int, page: int = 1, limit: int = 25):
+    def also(self, id: int, page: int = 1, limit: int = 25, **_):
         """Books co-downloaded with a given ebook."""
         page, limit = _paginate(page, limit)
         try:
@@ -1199,7 +1205,7 @@ class OPDSFeed:
     # Publications
 
     @cherrypy.expose
-    def publications(self, id: int):
+    def publications(self, id: int, **_):
         """Single publication by Gutenberg ebook number."""
         try:
             result = self.fts.execute(
@@ -1233,6 +1239,7 @@ class OPDSFeed:
         subject_id: Optional[int] = None,
         bookshelf_id: Optional[int] = None,
         modified_since: str = "",
+        **_,
     ):
         """Full-text search."""
         page, limit = _paginate(page, limit)
@@ -1361,7 +1368,7 @@ if __name__ == "__main__":
             cherrypy.response.body = b""
             cherrypy.request.handler = None
 
-    cherrypy.tree.mount(OPDSFeed(), "/opds", OPDS_MOUNT_CONFIG)
+    cherrypy.tree.mount(OPDSFeed(), "/opds", {"/": OPDS_MOUNT_CONFIG["/opds"]})
     try:
         cherrypy.engine.start()
         cherrypy.engine.block()

--- a/OPDS2.py
+++ b/OPDS2.py
@@ -21,7 +21,7 @@ from mv_search.constants import (
     SearchType,
     SortDirection,
 )
-from mv_search.crosswalks import _gutenberg_url
+from mv_search.crosswalks import _catalog_url
 from mv_search.Search import FullTextSearch
 
 OPDS = Crosswalk.OPDS
@@ -76,7 +76,7 @@ def _url(path: str, params: Optional[Dict] = None) -> str:
         clean = {k: v for k, v in params.items() if v not in ("", None)}
         if clean:
             path = f"{path}?{urlencode(clean, doseq=True)}"
-    return _gutenberg_url(path)
+    return _catalog_url(path)
 
 
 def _json_error_page(status, message, traceback, version):

--- a/OPDS2.py
+++ b/OPDS2.py
@@ -1,0 +1,1342 @@
+"""
+OPDS2.py — Zachary Rosario
+
+OPDS 2.0 JSON feed for the Project Gutenberg catalog.
+"""
+
+import datetime
+from typing import Callable, Dict, List, Optional, Tuple
+from urllib.parse import urlencode
+import logging
+import json
+
+import cherrypy
+
+from mv_search.constants import (
+    Crosswalk,
+    CuratedBookshelves,
+    Language,
+    OrderBy,
+    SearchField,
+    SearchType,
+    SortDirection,
+)
+from mv_search.Search import FullTextSearch
+
+OPDS = Crosswalk.OPDS
+OPDS_SMALL = Crosswalk.OPDS_SMALL
+
+SAMPLE_LIMIT = 15
+# Most common Gutenberg languages first, remainder alphabetical by label
+_LANG_PRIORITY = [
+    "en",
+    "fr",
+    "de",
+    "fi",
+    "nl",
+    "it",
+    "pt",
+    "es",
+    "zh",
+    "la",
+    "el",
+    "grc",
+    "hu",
+    "sv",
+    "da",
+    "no",
+    "pl",
+    "ru",
+    "cs",
+    "ja",
+]
+LANGUAGES = [
+    {"code": lang.code, "label": lang.label}
+    for lang in Language
+    if lang.code in _LANG_PRIORITY
+]
+LANGUAGES.sort(key=lambda x: _LANG_PRIORITY.index(x["code"]))
+LANGUAGE_LABELS = {lang.code: lang.label for lang in Language}
+
+VALID_SORTS = set(OrderBy._value2member_map_.keys())
+OPDS_TYPE = "application/opds+json"
+OPDS_PUBLICATION_TYPE = "application/opds-publication+json"
+# Only the user-facing search fields are advertised to clients. /opds/search
+# also accepts lang, sort, sort_order, locc, author_id, subject_id
+# and bookshelf_id for internal facet/scope carry-over, but those are kept out
+# of the template so clients don't surface them as search inputs.
+SEARCH_TEMPLATE = "/opds/search{?query,title,author}"
+
+
+# Helpers
+def _json_error_page(status, message, traceback, version):
+    cherrypy.response.status = status
+    cherrypy.response.headers["Content-Type"] = OPDS_TYPE
+    return json.dumps(
+        {
+            "metadata": {
+                "title": status,
+                "description": message,
+            },
+            "links": [
+                _link("self", cherrypy.request.path_info),
+                _link("start", "/opds/"),
+            ],
+            "publications": [],
+        }
+    )
+
+
+def _link(rel: str, href: str, **extras) -> Dict:
+    """Create an OPDS link dict."""
+    return {"rel": rel, "href": href, "type": OPDS_TYPE, **extras}
+
+
+OPDS_GZIP_MIME_TYPES = [
+    "application/json",
+    "application/opds+json",
+    "application/opds-publication+json",
+]
+
+OPDS_MOUNT_CONFIG = {
+    "/": {
+        "tools.response_headers.on": True,
+        "tools.json_in.on": True,
+        "tools.json_out.on": True,
+        "tools.gzip.on": True,
+        "tools.gzip.mime_types": OPDS_GZIP_MIME_TYPES,
+        "error_page.404": _json_error_page,
+        "error_page.500": _json_error_page,
+        "error_page.default": _json_error_page,
+        "tools.response_headers.headers": [
+            ("Content-Type", OPDS_TYPE),
+            ("Access-Control-Allow-Origin", "*"),
+            ("Access-Control-Allow-Methods", "GET"),
+            ("Access-Control-Allow-Headers", "Accept, Content-Type"),
+        ],
+    }
+}
+
+
+def _nav(href: str, title: str) -> Dict:
+    """Create a navigation item."""
+    return {"href": href, "title": title, "type": OPDS_TYPE, "rel": "subsection"}
+
+
+def _navigation_group() -> Dict:
+    """Homepage browse entry points."""
+    return {
+        "metadata": {"title": "Navigation", "numberOfItems": 2},
+        "navigation": [
+            _nav("/opds/bookshelves", "Browse Bookshelves"),
+            _nav("/opds/loccs", "Browse Subjects"),
+        ],
+    }
+
+
+def _facet(href: str, title: str, active: bool) -> Dict:
+    """Create a facet link. Includes 'rel': 'self' only if active."""
+    link = {"href": href, "type": OPDS_TYPE, "title": title}
+    if active:
+        link["rel"] = "self"
+    return link
+
+
+def _url(path: str, params: Dict) -> str:
+    """Build URL with query string, omitting empty values."""
+    clean = {k: v for k, v in params.items() if v not in ("", None)}
+    return f"{path}?{urlencode(clean, doseq=True)}" if clean else path
+
+
+def _make_page_url(endpoint: str, base: Dict, query: str = "") -> Callable[[int], str]:
+    """Create a page URL builder for pagination links."""
+
+    def page_url(p: int) -> str:
+        return _url(endpoint, {**base, "query": query, "page": p})
+
+    return page_url
+
+
+def _make_facet_url(endpoint: str, base: Dict) -> Callable[..., str]:
+    """Create a facet URL builder for filter facets."""
+
+    def facet_url(q: str, lng: str, srt: str, so: str) -> str:
+        return _url(
+            endpoint,
+            {
+                **base,
+                "query": q,
+                "page": 1,
+                "lang": lng,
+                "sort": srt,
+                "sort_order": so,
+            },
+        )
+
+    return facet_url
+
+
+def _paginate(page, limit, default=25) -> Tuple[int, int]:
+    """Parse and clamp pagination params."""
+    try:
+        return max(1, int(page)), max(1, min(100, int(limit)))
+    except (ValueError, TypeError):
+        return 1, default
+
+
+def _optional_int(value) -> Optional[int]:
+    """Parse CherryPy query params that may arrive as str, int, or empty."""
+    if value in (None, ""):
+        return None
+    return int(value)
+
+
+def _search_scope(
+    q,
+    query: str,
+    title: str,
+    author: str,
+    locc: str,
+    author_id: Optional[int],
+    bookshelf_id: Optional[int],
+):
+    """Apply search-route filters (not lang or subject_id)."""
+    if query.strip():
+        q.search(query, search_type=SearchType.HYBRID)
+    if title.strip():
+        q.search(title, field=SearchField.TITLE, search_type=SearchType.HYBRID)
+    if author.strip():
+        q.search(author, field=SearchField.AUTHOR, search_type=SearchType.HYBRID)
+    if locc:
+        q.locc(locc)
+    if author_id is not None:
+        q.author_id(author_id)
+    if bookshelf_id is not None:
+        q.bookshelf_id(bookshelf_id)
+    return q
+
+
+def _sort_direction(order: str) -> Optional[SortDirection]:
+    """Parse sort order string."""
+    return {"asc": SortDirection.ASC, "desc": SortDirection.DESC}.get(order)
+
+
+def _daily_seed() -> int:
+    """Day number used to rotate shelves once per day."""
+    return datetime.date.today().toordinal()
+
+
+def _book_id(pub: Dict) -> Optional[int]:
+    """Extract the numeric Gutenberg id from an OPDS publication."""
+    try:
+        ident = pub["metadata"]["identifier"]
+        if isinstance(ident, str) and "/ebooks/" in ident:
+            return int(ident.rstrip("/").rsplit("/", 1)[-1])
+    except (KeyError, ValueError, AttributeError, TypeError):
+        pass
+    return None
+
+
+# CherryPy Search API
+class OPDSFeed:
+    """OPDS 2 feed. List/catalog endpoints use OPDS_SMALL; only publications()
+    uses OPDS for full book detail."""
+
+    _CACHE_TTL = datetime.timedelta(hours=12)
+
+    def __init__(self):
+        self._fts = None
+        self._feed_cache = {}  # key -> (expires, feed)
+
+    @property
+    def fts(self):
+        if self._fts is None:
+            self._fts = FullTextSearch(cherrypy.engine.pool.pool)
+        return self._fts
+
+    # Query Helpers
+    def _filter(self, q, lang: str):
+        """Apply common filters to query."""
+        if lang:
+            q.lang(lang)
+        return q
+
+    def _sort(self, q, sort: str, sort_order: str):
+        """Apply sorting to query."""
+        if sort in VALID_SORTS:
+            q.order_by(OrderBy(sort), _sort_direction(sort_order))
+        else:
+            q.order_by(OrderBy.DOWNLOADS)
+        return q
+
+    def _cache_feed(
+        self,
+        key: str,
+        build: Callable[[], Dict],
+        *,
+        store: Callable[[Dict], bool],
+    ) -> Dict:
+        """Return a cached feed with a 12-hour TTL."""
+        hit = self._feed_cache.get(key)
+        if hit and datetime.datetime.now() < hit[0]:
+            return hit[1]
+        feed = build()
+        if store(feed):
+            self._feed_cache[key] = (
+                datetime.datetime.now() + self._CACHE_TTL,
+                feed,
+            )
+        return feed
+
+    def _shelf_sample(self, shelf_id: int, seen: set, with_count: bool) -> Dict:
+        """Top-downloaded sample for a shelf, excluding already-shown books."""
+        q = self.fts.query(crosswalk=OPDS_SMALL).bookshelf_id(shelf_id)
+        if seen:
+            q.where("book_id <> ALL(:seen_ids)", seen_ids=list(seen))
+        result = self.fts.execute(
+            q.order_by(OrderBy.DOWNLOADS)[1, SAMPLE_LIMIT], with_count=with_count
+        )
+        for pub in result.get("results", []):
+            bid = _book_id(pub)
+            if bid is not None:
+                seen.add(bid)
+        return result
+
+    def _category_count(self, cat) -> int:
+        """Count distinct books across all of a category's sub-shelves."""
+        try:
+            q = self.fts.query().where(
+                "EXISTS (SELECT 1 FROM mn_books_bookshelves mbb "
+                "WHERE mbb.fk_books = book_id "
+                "AND mbb.fk_bookshelves = ANY(:shelf_ids))",
+                shelf_ids=[sid for sid, _ in self.fts.curated_shelves(cat)],
+            )
+            return self.fts.count(q)
+        except Exception:
+            return 0
+
+    def _locc_nav_item_count(self, code: str) -> Optional[int]:
+        """Sub-subject count when a code has children; book count at leaves."""
+        try:
+            sub = self.fts.get_locc_children(code)
+            if sub:
+                return len(sub)
+            return self.fts.count(self.fts.query().locc(code))
+        except Exception as e:
+            cherrypy.log(
+                f"LoCC nav count error ({code}): {e}", severity=logging.WARNING
+            )
+            return None
+
+    # Feed Building
+    def _pagination_links(
+        self, url_fn: Callable, page: int, total_pages: int
+    ) -> List[Dict]:
+        """Build pagination links."""
+        links = []
+        if page > 1:
+            links.append(_link("first", url_fn(1)))
+            links.append(_link("previous", url_fn(page - 1)))
+        if page < total_pages:
+            links.append(_link("next", url_fn(page + 1)))
+            links.append(_link("last", url_fn(total_pages)))
+        return links
+
+    # Error handling
+
+    def _error_feed(
+        self,
+        title: str,
+        detail: str,
+        self_href: str,
+        up_href: str = "/opds/",
+        status: int = 500,
+    ) -> Dict:
+        cherrypy.response.status = status
+        return {
+            "metadata": {
+                "title": title,
+                "numberOfItems": 0,
+                "description": detail,
+            },
+            "links": [
+                _link("self", self_href),
+                _link("start", "/opds/"),
+                _link("up", up_href),
+            ],
+            "publications": [],
+        }
+
+    def _facets(
+        self,
+        url_fn: Callable,
+        query: str,
+        lang: str,
+        sort: str,
+        sort_order: str,
+        subjects: Optional[List[Dict]] = None,
+        languages: Optional[List[Dict]] = None,
+        scope: Optional[Dict] = None,
+        subject_id: Optional[int] = None,
+    ) -> List[Dict]:
+        """Build common facets for sort and language.
+
+        languages, when provided, drives a dynamic language facet (codes +
+        counts from the result set); otherwise a static common-language list
+        is used.
+
+        scope carries the current browse filters (e.g. bookshelf_id, locc) so
+        that clicking a Top Subject narrows within that scope instead of
+        dropping it.
+        """
+        sort_links = [
+            _facet(
+                url_fn(query, lang, "downloads", "desc"),
+                "Most Popular",
+                sort in ("downloads", ""),
+            ),
+            _facet(
+                url_fn(query, lang, "release_date", "desc"),
+                "Newest",
+                sort == "release_date",
+            ),
+        ]
+        if query:
+            sort_links.extend(
+                [
+                    _facet(
+                        url_fn(query, lang, "relevance", ""),
+                        "Relevance",
+                        sort == "relevance",
+                    ),
+                    _facet(
+                        url_fn(query, lang, "title", "asc"),
+                        "Title (A-Z)",
+                        sort == "title",
+                    ),
+                    _facet(
+                        url_fn(query, lang, "author", "asc"),
+                        "Author (A-Z)",
+                        sort == "author",
+                    ),
+                ]
+            )
+        sort_links.append(
+            _facet(
+                url_fn(query, lang, "random", ""),
+                "Random",
+                sort == "random",
+            )
+        )
+        facets = [
+            {
+                "metadata": {"title": "Sort By"},
+                "links": sort_links,
+            }
+        ]
+
+        if subjects:
+            facets.append(
+                {
+                    "metadata": {"title": "Top Subjects in Results"},
+                    "links": self._subject_links(
+                        scope, lang, sort, sort_order, subjects, subject_id
+                    ),
+                }
+            )
+
+        facets.append(
+            {
+                "metadata": {"title": "Language"},
+                "links": self._language_links(
+                    url_fn, query, lang, sort, sort_order, languages
+                ),
+            }
+        )
+        return facets
+
+    def _language_links(
+        self,
+        url_fn: Callable,
+        query: str,
+        lang: str,
+        sort: str,
+        sort_order: str,
+        languages: Optional[List[Dict]],
+    ) -> List[Dict]:
+        """Language facet links. Dynamic (with counts) when `languages` is
+        given, else the static common-language list."""
+        links = [
+            _facet(url_fn(query, "", sort, sort_order), "Any", not lang)
+        ]
+        if languages is not None:
+            items = [
+                (item["code"], LANGUAGE_LABELS.get(item["code"], item["code"]),
+                 item.get("count"))
+                for item in languages
+            ]
+        else:
+            items = [(item["code"], item["label"], None) for item in LANGUAGES]
+
+        for code, label, count in items:
+            link = _facet(
+                url_fn(query, code, sort, sort_order),
+                label,
+                lang == code,
+            )
+            if count is not None:
+                link["properties"] = {"numberOfItems": count}
+            links.append(link)
+        return links
+
+    def _subject_links(
+        self,
+        scope: Optional[Dict],
+        lang: str,
+        sort: str,
+        sort_order: str,
+        subjects: List[Dict],
+        subject_id: Optional[int],
+    ) -> List[Dict]:
+        """Subject facet links for search (dynamic counts, Any to clear)."""
+
+        def subject_url(**extra) -> str:
+            return _url(
+                "/opds/search",
+                {
+                    **(scope or {}),
+                    "lang": lang,
+                    "sort": sort,
+                    "sort_order": sort_order,
+                    **extra,
+                },
+            )
+
+        links = [_facet(subject_url(), "Any", subject_id is None)]
+        for s in subjects:
+            link = _facet(
+                subject_url(subject_id=s["id"]),
+                s["name"],
+                subject_id == s["id"],
+            )
+            link["properties"] = {"numberOfItems": s["count"]}
+            links.append(link)
+        return links
+
+    # Index
+    @cherrypy.expose
+    def index(self):
+        """Root catalog."""
+        return self._cache_feed(
+            "index", self._build_index, store=lambda feed: bool(feed.get("groups"))
+        )
+
+    def _build_index(self):
+        seen = set()
+        day = _daily_seed()
+
+        def _mark_seen(results):
+            for pub in results:
+                bid = _book_id(pub)
+                if bid is not None:
+                    seen.add(bid)
+
+        def _recently_added():
+            result = self.fts.execute(
+                self.fts.query(crosswalk=OPDS_SMALL).order_by(
+                    OrderBy.RELEASE_DATE, SortDirection.DESC
+                )[1, SAMPLE_LIMIT],
+            )
+            if result.get("results"):
+                _mark_seen(result["results"])
+                return {
+                    "metadata": {
+                        "title": "Recently Added",
+                        "numberOfItems": result["total"],
+                    },
+                    "links": [
+                        _link("self", "/opds/search?sort=release_date&sort_order=desc")
+                    ],
+                    "publications": result["results"],
+                }
+
+        def _most_popular():
+            result = self.fts.execute(
+                self.fts.query(crosswalk=OPDS_SMALL).order_by(OrderBy.DOWNLOADS)[
+                    1, SAMPLE_LIMIT
+                ],
+            )
+            if result.get("results"):
+                _mark_seen(result["results"])
+                return {
+                    "metadata": {
+                        "title": "Most Popular",
+                        "numberOfItems": result["total"],
+                    },
+                    "links": [
+                        _link("self", "/opds/search?sort=downloads&sort_order=desc")
+                    ],
+                    "publications": result["results"],
+                }
+
+        def _category_group(cat):
+            """Daily spotlight shelf (rotates by date), top picks, deduped."""
+            shelves = self.fts.curated_shelves(cat)
+            if not shelves:
+                return
+
+            for offset in range(len(shelves)):
+                shelf_id, _shelf_name = shelves[(day + offset) % len(shelves)]
+                try:
+                    result = self._shelf_sample(shelf_id, seen, with_count=False)
+                    if result.get("results"):
+                        return {
+                            "metadata": {
+                                "title": cat.genre,
+                                "numberOfItems": self._category_count(cat),
+                            },
+                            "links": [
+                                _link(
+                                    "self",
+                                    f"/opds/bookshelf_groups?category={cat.name}",
+                                )
+                            ],
+                            "publications": result["results"],
+                        }
+                except Exception as e:
+                    cherrypy.log(
+                        f"Index group error ({cat.name}/{shelf_id}): {e}",
+                        severity=logging.WARNING,
+                    )
+
+        tasks = [_recently_added, _most_popular] + [
+            lambda c=cat: _category_group(c) for cat in CuratedBookshelves
+        ]
+
+        groups = [_navigation_group()]
+        for fn in tasks:
+            try:
+                result = fn()
+                if result:
+                    groups.append(result)
+            except Exception as e:
+                cherrypy.log(f"Index group error: {e}")
+
+        return {
+            "metadata": {"title": "Project Gutenberg"},
+            "links": [
+                _link("self", "/opds/"),
+                _link("start", "/opds/"),
+                _link("search", SEARCH_TEMPLATE, templated=True),
+            ],
+            "groups": groups,
+        }
+
+    # Bookshelves
+    @cherrypy.expose
+    def bookshelves(
+        self,
+        id: Optional[int] = None,
+        category: Optional[str] = None,
+        page: int = 1,
+        limit: int = 25,
+        lang: str = "",
+        sort: str = "",
+        sort_order: str = "",
+    ):
+        """Bookshelf navigation."""
+        page, limit = _paginate(page, limit)
+
+        if id is not None:
+            return self._bookshelf_books(
+                int(id),
+                page,
+                limit,
+                lang,
+                sort,
+                sort_order,
+            )
+        if category is not None:
+            return self._bookshelf_category_nav(category)
+
+        return self._cache_feed(
+            "bookshelf_nav:_root",
+            self._build_bookshelf_navigation,
+            store=lambda feed: bool(feed.get("navigation")),
+        )
+
+    def _build_bookshelf_navigation(self) -> Dict:
+        """Build curated bookshelf category navigation."""
+        nav = []
+        for cat in CuratedBookshelves:
+            nav_item = _nav(f"/opds/bookshelves?category={cat.name}", cat.genre)
+            nav_item["properties"] = {"numberOfItems": len(cat.shelf_names)}
+            nav.append(nav_item)
+
+        return {
+            "metadata": {
+                "title": "Project Gutenberg",
+                "numberOfItems": len(CuratedBookshelves),
+            },
+            "links": [
+                _link("self", "/opds/bookshelves"),
+                _link("start", "/opds/"),
+                _link("up", "/opds/"),
+                _link("search", SEARCH_TEMPLATE, templated=True),
+            ],
+            "navigation": nav,
+        }
+
+    def _build_bookshelf_category_navigation(
+        self, category: str, cat: CuratedBookshelves
+    ) -> Dict:
+        """Build sub-shelf navigation for a curated category."""
+        nav = []
+        for sid, sname in self.fts.curated_shelves(cat):
+            nav_item = _nav(f"/opds/bookshelves?id={sid}", sname)
+            try:
+                count = self.fts.count(self.fts.query().bookshelf_id(sid))
+                if count:
+                    nav_item["properties"] = {"numberOfItems": count}
+            except Exception as e:
+                cherrypy.log(
+                    f"Bookshelf nav count error ({sid}): {e}",
+                    severity=logging.WARNING,
+                )
+            nav.append(nav_item)
+
+        return {
+            "metadata": {
+                "title": "Project Gutenberg",
+                "numberOfItems": len(nav),
+            },
+            "links": [
+                _link("self", f"/opds/bookshelves?category={category}"),
+                _link("start", "/opds/"),
+                _link("up", "/opds/bookshelves"),
+                _link("search", SEARCH_TEMPLATE, templated=True),
+            ],
+            "navigation": nav,
+        }
+
+    def _bookshelf_books(
+        self,
+        shelf_id: int,
+        page: int,
+        limit: int,
+        lang: str,
+        sort: str,
+        sort_order: str,
+    ):
+        """Browse books in a bookshelf."""
+        parent = None
+        for cat in CuratedBookshelves:
+            if any(sid == shelf_id for sid, _ in self.fts.curated_shelves(cat)):
+                parent = cat.name
+                break
+
+        try:
+            q = self.fts.query(crosswalk=OPDS_SMALL).bookshelf_id(shelf_id)
+            self._filter(q, lang)
+            self._sort(q, sort, sort_order)
+            result = self.fts.execute(q[page, limit])
+        except Exception as e:
+            cherrypy.log(f"Bookshelf error: {e}")
+            return self._error_feed(
+                "Browse failed",
+                "Unable to load bookshelf.",
+                f"/opds/bookshelves?id={shelf_id}",
+                status=500,
+            )
+
+        base = {
+            "id": shelf_id,
+            "limit": limit,
+            "lang": lang,
+            "sort": sort,
+            "sort_order": sort_order,
+        }
+        page_url = _make_page_url("/opds/bookshelves", base)
+        facet_url = _make_facet_url("/opds/bookshelves", base)
+
+        facet_counts = self.fts.get_opds_facets(
+            lambda q: q.bookshelf_id(shelf_id), lang=lang
+        )
+
+        up = f"/opds/bookshelves?category={parent}" if parent else "/opds/bookshelves"
+        feed = {
+            "metadata": {
+                "title": "Project Gutenberg",
+                "numberOfItems": result["total"],
+                "itemsPerPage": result["page_size"],
+                "currentPage": result["page"],
+            },
+            "links": [
+                _link("self", page_url(result["page"])),
+                _link("start", "/opds/"),
+                _link("up", up),
+                _link("search", SEARCH_TEMPLATE, templated=True),
+            ],
+            "publications": result["results"],
+            "facets": self._facets(
+                facet_url,
+                "",
+                lang,
+                sort,
+                sort_order,
+                facet_counts["subjects"],
+                facet_counts["languages"],
+                {"bookshelf_id": shelf_id},
+            ),
+        }
+        feed["links"].extend(
+            self._pagination_links(page_url, result["page"], result["total_pages"])
+        )
+        return feed
+
+    def _bookshelf_category_nav(self, category: str):
+        """Browse Bookshelves: sub-shelf links only (no publication previews)."""
+        found = next((cat for cat in CuratedBookshelves if cat.name == category), None)
+        if not found:
+            return self._error_feed(
+                "Category not found",
+                f"Bookshelf category {category} was not found.",
+                f"/opds/bookshelves?category={category}",
+                "/opds/bookshelves",
+                status=404,
+            )
+
+        return self._cache_feed(
+            f"bookshelf_nav:{category}",
+            lambda: self._build_bookshelf_category_navigation(category, found),
+            store=lambda feed: bool(feed.get("navigation")),
+        )
+
+    @cherrypy.expose
+    def bookshelf_groups(self, category: Optional[str] = None):
+        """Homepage-style category browse with per-shelf preview groups."""
+        if category is None:
+            return self._error_feed(
+                "Category required",
+                "A bookshelf category is required.",
+                "/opds/bookshelf_groups",
+                "/opds/",
+                status=400,
+            )
+        return self._bookshelf_category_groups(category)
+
+    def _bookshelf_category_groups(self, category: str):
+        """List shelves in a category with daily spotlight samples (cached)."""
+        found = next((cat for cat in CuratedBookshelves if cat.name == category), None)
+        if not found:
+            return self._error_feed(
+                "Category not found",
+                f"Bookshelf category {category} was not found.",
+                f"/opds/bookshelf_groups?category={category}",
+                "/opds/",
+                status=404,
+            )
+
+        def build():
+            seen = set()
+            day = _daily_seed()
+            shelves = self.fts.curated_shelves(found)
+            if not shelves:
+                return {"groups": []}
+            rotated = [shelves[(day + i) % len(shelves)] for i in range(len(shelves))]
+            groups = []
+            for sid, sname in rotated:
+                try:
+                    result = self._shelf_sample(sid, seen, with_count=True)
+                    if result.get("results"):
+                        groups.append(
+                            {
+                                "metadata": {
+                                    "title": sname,
+                                    "numberOfItems": result["total"],
+                                },
+                                "links": [
+                                    _link("self", f"/opds/bookshelves?id={sid}")
+                                ],
+                                "publications": result["results"],
+                            }
+                        )
+                except Exception as e:
+                    cherrypy.log(
+                        f"Bookshelf sample error {sid}: {e}",
+                        context="OPDS",
+                        severity=logging.WARNING,
+                    )
+
+            return {
+                "metadata": {
+                    "title": "Project Gutenberg",
+                    "numberOfItems": len(found.shelf_names),
+                },
+                "links": [
+                    _link("self", f"/opds/bookshelf_groups?category={category}"),
+                    _link("start", "/opds/"),
+                    _link("up", "/opds/"),
+                    _link("search", SEARCH_TEMPLATE, templated=True),
+                ],
+                "groups": groups,
+            }
+
+        return self._cache_feed(
+            f"cat:{category}", build, store=lambda feed: bool(feed.get("groups"))
+        )
+
+    # LoCC
+    @cherrypy.expose
+    def loccs(
+        self,
+        parent: str = "",
+        page: int = 1,
+        limit: int = 25,
+        lang: str = "",
+        sort: str = "",
+        sort_order: str = "",
+    ):
+        """LoCC hierarchical navigation."""
+        parent = (parent or "").strip().upper()
+        page, limit = _paginate(page, limit)
+
+        try:
+            children = self.fts.get_locc_children(parent)
+        except Exception as e:
+            cherrypy.log(f"LoCC error: {e}")
+            children = []
+
+        if children:
+            return self._cache_feed(
+                f"locc_nav:{parent or '_root'}",
+                lambda: self._build_locc_navigation(parent, children),
+                store=lambda feed: bool(feed.get("navigation")),
+            )
+
+        return self._locc_books(
+            parent, page, limit, lang, sort, sort_order
+        )
+
+    def _build_locc_navigation(self, parent: str, children: List) -> Dict:
+        """Build LoCC category navigation."""
+        children.sort(key=lambda x: (len(x.get("code", "")), x.get("code", "")))
+
+        nav = []
+        for child in children:
+            code = child["code"]
+            label = child.get("label") or code
+            if parent:
+                _, sep, rest = label.partition(":")
+                if sep:
+                    label = rest.strip()
+            count = self._locc_nav_item_count(code)
+            if not count:
+                continue
+            nav_item = _nav(f"/opds/loccs?parent={code}", label)
+            nav_item["properties"] = {"numberOfItems": count}
+            nav.append(nav_item)
+
+        return {
+            "metadata": {"title": "Project Gutenberg", "numberOfItems": len(nav)},
+            "links": [
+                _link(
+                    "self", f"/opds/loccs?parent={parent}" if parent else "/opds/loccs"
+                ),
+                _link("start", "/opds/"),
+                _link("up", "/opds/loccs" if parent else "/opds/"),
+                _link("search", SEARCH_TEMPLATE, templated=True),
+            ],
+            "navigation": nav,
+        }
+
+    def _locc_books(
+        self,
+        parent: str,
+        page: int,
+        limit: int,
+        lang: str,
+        sort: str,
+        sort_order: str,
+    ):
+        """Browse books in a LoCC leaf."""
+        try:
+            q = self.fts.query(crosswalk=OPDS_SMALL).locc(parent)
+            self._filter(q, lang)
+            self._sort(q, sort, sort_order)
+            result = self.fts.execute(q[page, limit])
+        except Exception as e:
+            cherrypy.log(f"LoCC browse error: {e}")
+            return self._error_feed(
+                "Browse failed",
+                "Unable to load LoCC leaf.",
+                f"/opds/loccs?parent={parent}",
+                "/opds/loccs",
+                status=500,
+            )
+
+        base = {
+            "parent": parent,
+            "limit": limit,
+            "lang": lang,
+            "sort": sort,
+            "sort_order": sort_order,
+        }
+        page_url = _make_page_url("/opds/loccs", base)
+        facet_url = _make_facet_url("/opds/loccs", base)
+
+        facet_counts = self.fts.get_opds_facets(lambda q: q.locc(parent), lang=lang)
+
+        feed = {
+            "metadata": {
+                "title": "Project Gutenberg",
+                "numberOfItems": result["total"],
+                "itemsPerPage": result["page_size"],
+                "currentPage": result["page"],
+            },
+            "links": [
+                _link("self", page_url(result["page"])),
+                _link("start", "/opds/"),
+                _link("up", "/opds/loccs"),
+                _link("search", SEARCH_TEMPLATE, templated=True),
+            ],
+            "publications": result["results"],
+            "facets": self._facets(
+                facet_url,
+                "",
+                lang,
+                sort,
+                sort_order,
+                facet_counts["subjects"],
+                facet_counts["languages"],
+                {"locc": parent},
+            ),
+        }
+        feed["links"].extend(
+            self._pagination_links(page_url, result["page"], result["total_pages"])
+        )
+        return feed
+
+    # Subjects
+
+    def _build_subjects_index(self) -> Dict:
+        subjects = sorted(
+            self.fts.list_subjects(), key=lambda x: x["book_count"], reverse=True
+        )[:100]
+        return {
+            "metadata": {"title": "Project Gutenberg", "numberOfItems": len(subjects)},
+            "links": [
+                _link("self", "/opds/subjects"),
+                _link("start", "/opds/"),
+                _link("up", "/opds/"),
+                _link("search", SEARCH_TEMPLATE, templated=True),
+            ],
+            "navigation": [
+                {
+                    **_nav(f"/opds/subjects?id={s['id']}", s["name"]),
+                    "properties": {"numberOfItems": s["book_count"]},
+                }
+                for s in subjects
+            ],
+        }
+
+    @cherrypy.expose
+    def subjects(
+        self,
+        id: Optional[int] = None,
+        page: int = 1,
+        limit: int = 25,
+        lang: str = "",
+        sort: str = "",
+        sort_order: str = "",
+    ):
+        """Subject navigation."""
+        page, limit = _paginate(page, limit)
+
+        if id is not None:
+            return self._subject_books(
+                int(id),
+                page,
+                limit,
+                lang,
+                sort,
+                sort_order,
+            )
+
+        return self._build_subjects_index()
+
+    def _subject_books(
+        self,
+        subject_id: int,
+        page: int,
+        limit: int,
+        lang: str,
+        sort: str,
+        sort_order: str,
+    ):
+        """Browse books for a subject."""
+        try:
+            q = self.fts.query(crosswalk=OPDS_SMALL).subject_id(subject_id)
+            self._filter(q, lang)
+            self._sort(q, sort, sort_order)
+            result = self.fts.execute(q[page, limit])
+        except Exception as e:
+            cherrypy.log(f"Subject error: {e}")
+            return self._error_feed(
+                "Browse failed",
+                "Unable to load subject.",
+                f"/opds/subjects?id={subject_id}",
+                "/opds/subjects",
+                status=500,
+            )
+
+        base = {
+            "id": subject_id,
+            "limit": limit,
+            "lang": lang,
+            "sort": sort,
+            "sort_order": sort_order,
+        }
+        page_url = _make_page_url("/opds/subjects", base)
+        facet_url = _make_facet_url("/opds/subjects", base)
+
+        facet_counts = self.fts.get_opds_facets(
+            lambda q: q.subject_id(subject_id),
+            lang=lang,
+            include_subjects=False,
+        )
+
+        feed = {
+            "metadata": {
+                "title": "Project Gutenberg",
+                "numberOfItems": result["total"],
+                "itemsPerPage": result["page_size"],
+                "currentPage": result["page"],
+            },
+            "links": [
+                _link("self", page_url(result["page"])),
+                _link("start", "/opds/"),
+                _link("up", "/opds/subjects"),
+                _link("search", SEARCH_TEMPLATE, templated=True),
+            ],
+            "publications": result["results"],
+            "facets": self._facets(
+                facet_url,
+                "",
+                lang,
+                sort,
+                sort_order,
+                languages=facet_counts["languages"],
+            ),
+        }
+        feed["links"].extend(
+            self._pagination_links(page_url, result["page"], result["total_pages"])
+        )
+        return feed
+
+    # Also downloaded
+
+    @cherrypy.expose
+    def also(self, id: int, page: int = 1, limit: int = 25):
+        """Books co-downloaded with a given ebook."""
+        page, limit = _paginate(page, limit)
+        try:
+            result = self.fts.execute(
+                self.fts.query(crosswalk=OPDS_SMALL).also_downloaded(int(id))[
+                    page, limit
+                ]
+            )
+        except Exception as e:
+            cherrypy.log(f"Also downloaded error: {e}")
+            return self._error_feed(
+                "Browse failed",
+                "Unable to load also-downloaded books.",
+                f"/opds/also?id={id}",
+                f"/opds/publications?id={id}",
+                status=500,
+            )
+
+        base = {"id": id, "limit": limit}
+        page_url = _make_page_url("/opds/also", base)
+        feed = {
+            "metadata": {
+                "title": "Readers also downloaded",
+                "numberOfItems": result["total"],
+                "itemsPerPage": result["page_size"],
+                "currentPage": result["page"],
+            },
+            "links": [
+                _link("self", page_url(result["page"])),
+                _link("start", "/opds/"),
+                _link("up", f"/opds/publications?id={id}"),
+            ],
+            "publications": result["results"],
+        }
+        feed["links"].extend(
+            self._pagination_links(page_url, result["page"], result["total_pages"])
+        )
+        return feed
+
+    # Publications
+
+    @cherrypy.expose
+    def publications(self, id: int):
+        """Single publication by Gutenberg ebook number."""
+        try:
+            result = self.fts.execute(
+                self.fts.query(crosswalk=OPDS).etext(int(id))[1, 1]
+            )
+        except Exception as e:
+            cherrypy.log(f"Publication error: {e}")
+            raise cherrypy.HTTPError(500, "Unable to load publication.")
+
+        if not result.get("results"):
+            raise cherrypy.HTTPError(404, "No ebook by that number.")
+
+        cherrypy.response.headers["Content-Type"] = OPDS_PUBLICATION_TYPE
+        return result["results"][0]
+
+    # Search
+
+    @cherrypy.expose
+    def search(
+        self,
+        query: str = "",
+        title: str = "",
+        author: str = "",
+        page: int = 1,
+        limit: int = 25,
+        lang: str = "",
+        sort: str = "",
+        sort_order: str = "",
+        locc: str = "",
+        author_id: Optional[int] = None,
+        subject_id: Optional[int] = None,
+        bookshelf_id: Optional[int] = None,
+    ):
+        """Full-text search."""
+        page, limit = _paginate(page, limit)
+        subject_id = _optional_int(subject_id)
+        author_id = _optional_int(author_id)
+        bookshelf_id = _optional_int(bookshelf_id)
+
+        try:
+            scope = lambda q: _search_scope(
+                q, query, title, author, locc, author_id, bookshelf_id
+            )
+            facet_counts = self.fts.get_opds_facets(
+                scope, lang=lang, subject_id=subject_id
+            )
+
+            q = self.fts.query(crosswalk=OPDS_SMALL)
+            scope(q)
+            if lang:
+                q.lang(lang)
+            if subject_id is not None:
+                q.subject_id(subject_id)
+            self._sort(q, sort, sort_order)
+            result = self.fts.execute(q[page, limit])
+        except Exception as e:
+            cherrypy.log(f"Search error: {e}")
+            return self._error_feed(
+                "Search failed",
+                "Unable to complete search.",
+                "/opds/search",
+                "/opds/",
+                status=500,
+            )
+
+        base = {
+            "limit": limit,
+            "title": title,
+            "author": author,
+            "lang": lang,
+            "sort": sort,
+            "sort_order": sort_order,
+            "locc": locc,
+            "author_id": author_id,
+            "subject_id": subject_id,
+            "bookshelf_id": bookshelf_id,
+        }
+        page_url = _make_page_url("/opds/search", base, query)
+        facet_url = _make_facet_url("/opds/search", base)
+
+        # Scope carried when narrowing to a Top Subject (subject_id is set by the
+        # facet itself, so it's excluded here to allow switching subjects).
+        search_scope = {
+            "query": query,
+            "title": title,
+            "author": author,
+            "locc": locc,
+            "author_id": author_id,
+            "bookshelf_id": bookshelf_id,
+        }
+        facets = self._facets(
+            facet_url, query, lang, sort, sort_order,
+            facet_counts["subjects"], facet_counts["languages"],
+            search_scope, subject_id=subject_id,
+        )
+
+        feed = {
+            "metadata": {
+                "title": "Project Gutenberg",
+                "numberOfItems": result["total"],
+                "itemsPerPage": result["page_size"],
+                "currentPage": result["page"],
+            },
+            "links": [
+                _link("self", page_url(result["page"])),
+                _link("start", "/opds/"),
+                _link("up", "/opds/"),
+                _link("search", SEARCH_TEMPLATE, templated=True),
+            ],
+            "publications": result["results"],
+            "facets": facets,
+        }
+        feed["links"].extend(
+            self._pagination_links(page_url, result["page"], result["total_pages"])
+        )
+        return feed
+
+
+if __name__ == "__main__":
+    import os
+
+    from cherrypy.process import plugins
+    from libgutenberg import GutenbergDatabase
+
+    import ConnectionPool  # noqa: F401  registers plugins.ConnectionPool
+
+    _local_conf = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test.conf")
+    if os.path.exists(_local_conf):
+        cherrypy.config.update(_local_conf)
+    cherrypy.config.update(
+        {"server.socket_host": "0.0.0.0", "server.socket_port": 8080}
+    )
+
+    GutenbergDatabase.options.update(cherrypy.config)
+    cherrypy.engine.pool = plugins.ConnectionPool(
+        cherrypy.engine,
+        params=GutenbergDatabase.get_connection_params(cherrypy.config),
+    )
+    cherrypy.engine.pool.subscribe()
+
+    @cherrypy.tools.register("before_finalize")
+    def cors():
+        cherrypy.response.headers["Access-Control-Allow-Origin"] = "*"
+        cherrypy.response.headers["Access-Control-Allow-Methods"] = "GET, OPTIONS"
+        cherrypy.response.headers["Access-Control-Allow-Headers"] = (
+            "Content-Type, Accept"
+        )
+        cherrypy.response.headers["Access-Control-Max-Age"] = "86400"
+        if cherrypy.request.method == "OPTIONS":
+            cherrypy.response.status = 200
+            cherrypy.response.body = b""
+            cherrypy.request.handler = None
+
+    cherrypy.tree.mount(OPDSFeed(), "/opds", OPDS_MOUNT_CONFIG)
+    try:
+        cherrypy.engine.start()
+        cherrypy.engine.block()
+    except KeyboardInterrupt:
+        cherrypy.engine.exit()

--- a/OPDS2.py
+++ b/OPDS2.py
@@ -21,6 +21,7 @@ from mv_search.constants import (
     SearchType,
     SortDirection,
 )
+from mv_search.crosswalks import _gutenberg_url
 from mv_search.Search import FullTextSearch
 
 OPDS = Crosswalk.OPDS
@@ -69,6 +70,15 @@ SEARCH_TEMPLATE = "/opds/search{?query,title,author}"
 
 
 # Helpers
+def _url(path: str, params: Optional[Dict] = None) -> str:
+    """Build an absolute catalog URL, optionally with query params."""
+    if params:
+        clean = {k: v for k, v in params.items() if v not in ("", None)}
+        if clean:
+            path = f"{path}?{urlencode(clean, doseq=True)}"
+    return _gutenberg_url(path)
+
+
 def _json_error_page(status, message, traceback, version):
     cherrypy.response.status = status
     cherrypy.response.headers["Content-Type"] = OPDS_TYPE
@@ -89,7 +99,7 @@ def _json_error_page(status, message, traceback, version):
 
 def _link(rel: str, href: str, **extras) -> Dict:
     """Create an OPDS link dict."""
-    return {"rel": rel, "href": href, "type": OPDS_TYPE, **extras}
+    return {"rel": rel, "href": _url(href), "type": OPDS_TYPE, **extras}
 
 
 OPDS_GZIP_MIME_TYPES = [
@@ -120,7 +130,7 @@ OPDS_MOUNT_CONFIG = {
 
 def _nav(href: str, title: str) -> Dict:
     """Create a navigation item."""
-    return {"href": href, "title": title, "type": OPDS_TYPE, "rel": "subsection"}
+    return {"href": _url(href), "title": title, "type": OPDS_TYPE, "rel": "subsection"}
 
 
 def _navigation_group() -> Dict:
@@ -136,16 +146,10 @@ def _navigation_group() -> Dict:
 
 def _facet(href: str, title: str, active: bool) -> Dict:
     """Create a facet link. Includes 'rel': 'self' only if active."""
-    link = {"href": href, "type": OPDS_TYPE, "title": title}
+    link = {"href": _url(href), "type": OPDS_TYPE, "title": title}
     if active:
         link["rel"] = "self"
     return link
-
-
-def _url(path: str, params: Dict) -> str:
-    """Build URL with query string, omitting empty values."""
-    clean = {k: v for k, v in params.items() if v not in ("", None)}
-    return f"{path}?{urlencode(clean, doseq=True)}" if clean else path
 
 
 def _make_page_url(endpoint: str, base: Dict, query: str = "") -> Callable[[int], str]:

--- a/OPDS2.py
+++ b/OPDS2.py
@@ -402,25 +402,27 @@ class OPDSFeed:
             ),
         ]
         if query:
-            sort_links.extend(
-                [
-                    _facet(
-                        url_fn(query, lang, "relevance", ""),
-                        "Relevance",
-                        sort == "relevance",
-                    ),
-                    _facet(
-                        url_fn(query, lang, "title", "asc"),
-                        "Title (A-Z)",
-                        sort == "title",
-                    ),
-                    _facet(
-                        url_fn(query, lang, "author", "asc"),
-                        "Author (A-Z)",
-                        sort == "author",
-                    ),
-                ]
+            sort_links.append(
+                _facet(
+                    url_fn(query, lang, "relevance", ""),
+                    "Relevance",
+                    sort == "relevance",
+                )
             )
+        sort_links.extend(
+            [
+                _facet(
+                    url_fn(query, lang, "title", "asc"),
+                    "Title (A-Z)",
+                    sort == "title",
+                ),
+                _facet(
+                    url_fn(query, lang, "author", "asc"),
+                    "Author (A-Z)",
+                    sort == "author",
+                ),
+            ]
+        )
         sort_links.append(
             _facet(
                 url_fn(query, lang, "random", ""),

--- a/OPDS2.py
+++ b/OPDS2.py
@@ -201,6 +201,7 @@ def _search_scope(
     bookshelf_id: Optional[int],
 ):
     """Apply search-route filters (not lang or subject_id)."""
+    q.text_only()
     if query.strip():
         q.search(query, search_type=SearchType.HYBRID)
     if title.strip():
@@ -255,8 +256,18 @@ class OPDSFeed:
         return self._fts
 
     # Query Helpers
+    def _query(self, crosswalk=None):
+        """OPDS catalog queries always exclude audiobooks."""
+        q = (
+            self.fts.query(crosswalk=crosswalk)
+            if crosswalk is not None
+            else self.fts.query()
+        )
+        return q.text_only()
+
     def _filter(self, q, lang: str):
         """Apply common filters to query."""
+        q.text_only()
         if lang:
             q.lang(lang)
         return q
@@ -290,7 +301,7 @@ class OPDSFeed:
 
     def _shelf_sample(self, shelf_id: int, seen: set, with_count: bool) -> Dict:
         """Top-downloaded sample for a shelf, excluding already-shown books."""
-        q = self.fts.query(crosswalk=OPDS_SMALL).bookshelf_id(shelf_id)
+        q = self._query(OPDS_SMALL).bookshelf_id(shelf_id)
         if seen:
             q.where("book_id <> ALL(:seen_ids)", seen_ids=list(seen))
         result = self.fts.execute(
@@ -305,7 +316,7 @@ class OPDSFeed:
     def _category_count(self, cat) -> int:
         """Count distinct books across all of a category's sub-shelves."""
         try:
-            q = self.fts.query().where(
+            q = self._query().where(
                 "EXISTS (SELECT 1 FROM mn_books_bookshelves mbb "
                 "WHERE mbb.fk_books = book_id "
                 "AND mbb.fk_bookshelves = ANY(:shelf_ids))",
@@ -321,7 +332,7 @@ class OPDSFeed:
             sub = self.fts.get_locc_children(code)
             if sub:
                 return len(sub)
-            return self.fts.count(self.fts.query().locc(code))
+            return self.fts.count(self._query().locc(code))
         except Exception as e:
             cherrypy.log(
                 f"LoCC nav count error ({code}): {e}", severity=logging.WARNING
@@ -545,7 +556,7 @@ class OPDSFeed:
 
         def _recently_added():
             result = self.fts.execute(
-                self.fts.query(crosswalk=OPDS_SMALL).order_by(
+                self._query(OPDS_SMALL).order_by(
                     OrderBy.RELEASE_DATE, SortDirection.DESC
                 )[1, SAMPLE_LIMIT],
             )
@@ -564,7 +575,7 @@ class OPDSFeed:
 
         def _most_popular():
             result = self.fts.execute(
-                self.fts.query(crosswalk=OPDS_SMALL).order_by(OrderBy.DOWNLOADS)[
+                self._query(OPDS_SMALL).order_by(OrderBy.DOWNLOADS)[
                     1, SAMPLE_LIMIT
                 ],
             )
@@ -697,7 +708,7 @@ class OPDSFeed:
         for sid, sname in self.fts.curated_shelves(cat):
             nav_item = _nav(f"/opds/bookshelves?id={sid}", sname)
             try:
-                count = self.fts.count(self.fts.query().bookshelf_id(sid))
+                count = self.fts.count(self._query().bookshelf_id(sid))
                 if count:
                     nav_item["properties"] = {"numberOfItems": count}
             except Exception as e:
@@ -738,7 +749,7 @@ class OPDSFeed:
                 break
 
         try:
-            q = self.fts.query(crosswalk=OPDS_SMALL).bookshelf_id(shelf_id)
+            q = self._query(OPDS_SMALL).bookshelf_id(shelf_id)
             self._filter(q, lang)
             self._sort(q, sort, sort_order)
             result = self.fts.execute(q[page, limit])
@@ -762,7 +773,7 @@ class OPDSFeed:
         facet_url = _make_facet_url("/opds/bookshelves", base)
 
         facet_counts = self.fts.get_opds_facets(
-            lambda q: q.bookshelf_id(shelf_id), lang=lang
+            lambda q: q.text_only().bookshelf_id(shelf_id), lang=lang
         )
 
         up = f"/opds/bookshelves?category={parent}" if parent else "/opds/bookshelves"
@@ -963,7 +974,7 @@ class OPDSFeed:
     ):
         """Browse books in a LoCC leaf."""
         try:
-            q = self.fts.query(crosswalk=OPDS_SMALL).locc(parent)
+            q = self._query(OPDS_SMALL).locc(parent)
             self._filter(q, lang)
             self._sort(q, sort, sort_order)
             result = self.fts.execute(q[page, limit])
@@ -987,7 +998,9 @@ class OPDSFeed:
         page_url = _make_page_url("/opds/loccs", base)
         facet_url = _make_facet_url("/opds/loccs", base)
 
-        facet_counts = self.fts.get_opds_facets(lambda q: q.locc(parent), lang=lang)
+        facet_counts = self.fts.get_opds_facets(
+            lambda q: q.text_only().locc(parent), lang=lang
+        )
 
         feed = {
             "metadata": {
@@ -1078,7 +1091,7 @@ class OPDSFeed:
     ):
         """Browse books for a subject."""
         try:
-            q = self.fts.query(crosswalk=OPDS_SMALL).subject_id(subject_id)
+            q = self._query(OPDS_SMALL).subject_id(subject_id)
             self._filter(q, lang)
             self._sort(q, sort, sort_order)
             result = self.fts.execute(q[page, limit])
@@ -1103,7 +1116,7 @@ class OPDSFeed:
         facet_url = _make_facet_url("/opds/subjects", base)
 
         facet_counts = self.fts.get_opds_facets(
-            lambda q: q.subject_id(subject_id),
+            lambda q: q.text_only().subject_id(subject_id),
             lang=lang,
             include_subjects=False,
         )
@@ -1144,7 +1157,7 @@ class OPDSFeed:
         page, limit = _paginate(page, limit)
         try:
             result = self.fts.execute(
-                self.fts.query(crosswalk=OPDS_SMALL).also_downloaded(int(id))[
+                self._query(OPDS_SMALL).also_downloaded(int(id))[
                     page, limit
                 ]
             )
@@ -1186,7 +1199,7 @@ class OPDSFeed:
         """Single publication by Gutenberg ebook number."""
         try:
             result = self.fts.execute(
-                self.fts.query(crosswalk=OPDS).etext(int(id))[1, 1]
+                self._query(OPDS).etext(int(id))[1, 1]
             )
         except Exception as e:
             cherrypy.log(f"Publication error: {e}")
@@ -1230,7 +1243,7 @@ class OPDSFeed:
                 scope, lang=lang, subject_id=subject_id
             )
 
-            q = self.fts.query(crosswalk=OPDS_SMALL)
+            q = self._query(OPDS_SMALL)
             scope(q)
             if lang:
                 q.lang(lang)

--- a/OPDS2.py
+++ b/OPDS2.py
@@ -251,7 +251,7 @@ class OPDSFeed:
     @property
     def fts(self):
         if self._fts is None:
-            self._fts = FullTextSearch(cherrypy.engine.pool.pool)
+            self._fts = FullTextSearch(cherrypy.engine.pool.engine)
         return self._fts
 
     # Query Helpers

--- a/OPDS2.py
+++ b/OPDS2.py
@@ -63,9 +63,9 @@ VALID_SORTS = set(OrderBy._value2member_map_.keys())
 OPDS_TYPE = "application/opds+json"
 OPDS_PUBLICATION_TYPE = "application/opds-publication+json"
 # Only the user-facing search fields are advertised to clients. /opds/search
-# also accepts lang, sort, sort_order, locc, author_id, subject_id
-# and bookshelf_id for internal facet/scope carry-over, but those are kept out
-# of the template so clients don't surface them as search inputs.
+# also accepts lang, sort, sort_order, locc, author_id, subject_id,
+# bookshelf_id, and modified_since for internal/secret facet/scope carry-over, but those
+# are kept out of the template so clients don't surface them as search inputs.
 SEARCH_TEMPLATE = "/opds/search{?query,title,author}"
 
 
@@ -1232,6 +1232,7 @@ class OPDSFeed:
         author_id: Optional[int] = None,
         subject_id: Optional[int] = None,
         bookshelf_id: Optional[int] = None,
+        modified_since: str = "",
     ):
         """Full-text search."""
         page, limit = _paginate(page, limit)
@@ -1240,9 +1241,14 @@ class OPDSFeed:
         bookshelf_id = _optional_int(bookshelf_id)
 
         try:
-            scope = lambda q: _search_scope(
-                q, query, title, author, locc, author_id, bookshelf_id
-            )
+            def scope(q):
+                _search_scope(
+                    q, query, title, author, locc, author_id, bookshelf_id
+                )
+                if modified_since:
+                    q.modified_after(modified_since)
+                return q
+
             facet_counts = self.fts.get_opds_facets(
                 scope, lang=lang, subject_id=subject_id
             )
@@ -1276,6 +1282,7 @@ class OPDSFeed:
             "author_id": author_id,
             "subject_id": subject_id,
             "bookshelf_id": bookshelf_id,
+            "modified_since": modified_since,
         }
         page_url = _make_page_url("/opds/search", base, query)
         facet_url = _make_facet_url("/opds/search", base)
@@ -1289,6 +1296,7 @@ class OPDSFeed:
             "locc": locc,
             "author_id": author_id,
             "bookshelf_id": bookshelf_id,
+            "modified_since": modified_since,
         }
         facets = self._facets(
             facet_url, query, lang, sort, sort_order,

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # autocat3_original
-## Introduction
 
-**autocat3** is a python-based application used for supporting [Project Gutenberg](gutenberg.org).
+**autocat3** is a Python/CherryPy application that serves dynamic content for [Project Gutenberg](https://www.gutenberg.org). 
 
 CherryPy is used as the web framwork which is easy to develop.
 
-It mainly implements the search functionality and rate limiter. Also return results pages based on templates. 
+It mainly implements the search functionality and rate limiter. Also return results pages based on templates.
 
 ## How it works.
 The production version of autocat3 is on **app1**.  
@@ -17,24 +16,142 @@ The virtual env directory is on the default directory while we run ```pipenv --t
 
 To start the service/application, we use **systemd** to do that. the ```autocat3.service``` file is written under ```/etc/systemd/system```directory. 
 
-*To start*:
+## How to Install
 
-1. make sure ```sudo systemctl daemon-reload``` every time we edit the systemd unit file
-2. ```sudo systemctl start autocat3.service``` to start service
-3. ```sudo systemctl stop autocat3.service``` to stop service
-4. ```sudo systemctl status autocat3.service``` to check the running status of the service
+### Prerequisites
 
-## How to install
-Currently, we use the following steps to deploy autocat3 on a different server.
-1. **Create Virtual env**: ```pipenv --three``` to create a virtual env for current working directory(current project)
-2. **Install packages/python modules**: ```pipenv install``` to install all the packages in the Pipfile. If there is a requirements.txt file output from ```pip freeze```, the command will automatically add the package names into Pipfile and install the packages and keep them in the Popfile for later use. 
-3. **Lock the packages**: ```pipenv lock``` to be used to produce deterministic builds.
-4. **Check the virtual env path**: ```pipenv --venv```
-5. **Start virtual env**: ```pipenv shell```
+- PostgreSQL with the `gutenberg` database already populated
+- Root or sudo access
 
-Lots of Information on configuring Autocat3 is in configuring.txt
+### 1. Install pyenv, pipenv, and the required Python version
 
+Install [pyenv](https://github.com/pyenv/pyenv#installation) (see [build prerequisites](https://github.com/pyenv/pyenv/wiki#suggested-build-environment) if needed) so that pipenv can install the required Python version. Then install pipenv:
 
-Copyright 2009-2010 by Marcello Perathoner
-Copyright 2019-present by Project Gutenberg
+```bash
+pip install pipenv
+```
 
+### 2. Create the autocat user and directories
+
+```bash
+sudo useradd -r -m -d /var/lib/autocat -s /bin/bash autocat
+sudo mkdir -p /var/lib/autocat/autocat3
+sudo mkdir -p /var/lib/autocat/log
+sudo mkdir -p /var/run/autocat
+sudo chown -R autocat:autocat /var/lib/autocat
+sudo chown -R autocat:autocat /var/run/autocat
+```
+
+### 3. Clone the repository
+
+```bash
+git clone https://github.com/zachjesus/autocat3.git /tmp/autocat3
+sudo cp -r /tmp/autocat3/* /var/lib/autocat/autocat3/
+sudo chown -R autocat:autocat /var/lib/autocat
+```
+
+### 4. Install dependencies
+
+pipenv reads the `Pipfile` and auto-detects Python 3.6 from pyenv. Setting `PIPENV_VENV_IN_PROJECT` puts the virtualenv in `.venv/` inside the project directory so the systemd service can find it.
+
+```bash
+cd /var/lib/autocat/autocat3
+sudo -u autocat PIPENV_VENV_IN_PROJECT=1 pipenv install
+```
+
+Verify:
+
+```bash
+sudo -u autocat /var/lib/autocat/autocat3/.venv/bin/python --version
+```
+
+### 5. Create the materialized view
+
+Until this is merged officially, the scripts live in [gutenbergtools/pgdb PR #15](https://github.com/gutenbergtools/pgdb/pull/15).
+Clone the repo, check out that PR, and run the scripts against your `gutenberg`
+database. pg_trgm is now managed by its own scripts, so they must be run in
+order, and a few require the `postgres` superuser.
+
+```bash
+git clone https://github.com/gutenbergtools/pgdb.git
+cd pgdb
+git fetch origin pull/15/head:full-mv-patch
+git checkout full-mv-patch
+```
+
+Run these in order:
+
+```bash
+# 1. Prep: drop objects depending on the old (unpackaged) pg_trgm — run as gutenberg
+psql -U gutenberg -d gutenberg -f 15_prep_pg_trgm_install.sql
+
+# 2. Drop leftover unpackaged pg_trgm artifacts — MUST run as the postgres superuser
+psql -U postgres -d gutenberg -f 16_drop_pg_trgm_artifacts.sql
+
+# 3. Install the pg_trgm extension and recreate its indexes — MUST run as postgres
+psql -U postgres -d gutenberg -f 17_install_pg_trgm_extension.sql
+
+# 4. Create the materialized view — run as the same user you will use for pguser
+psql -U gutenberg -d gutenberg -f 18_materialized_view.sql
+```
+
+To avoid permission errors, create the materialized view (step 4) as the same
+user you will be using for `pguser` in the next step.
+
+### 6. Configure
+
+Edit `/etc/autocat3.conf` (or `~/.autocat3` under the autocat user) to override defaults from `CherryPy.conf`. At minimum, set your database credentials and hosts:
+
+```ini
+[global]
+pghost:     'localhost'
+pgport:     5432
+pgdatabase: 'gutenberg'
+pguser:     'postgres'
+```
+
+The user must have sufficient permissions to access all public tables and refresh the materialized view.
+
+To change when the materialized view refreshes (default 5 PM server time):
+
+```ini
+mv_refresh_hour: 17
+```
+
+Other information on configuring Autocat3 can be found in configuring.txt
+
+### 7. Install the systemd service
+
+The service runs the app using the venv's Python directly:
+
+```bash
+sudo cp /var/lib/autocat/autocat3/autocat3.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable autocat3.service
+```
+
+### 8. Start the service
+
+```bash
+sudo systemctl start autocat3.service
+```
+
+Check status:
+
+```bash
+sudo systemctl status autocat3.service
+```
+
+Logs are written to `/var/lib/autocat/log/error.log` and `/var/lib/autocat/log/access.log`.
+
+Some common service commands are:
+
+```bash
+sudo systemctl start autocat3.service    # Start
+sudo systemctl stop autocat3.service     # Stop
+sudo systemctl restart autocat3.service  # Restart
+sudo systemctl status autocat3.service   # Check status
+sudo systemctl daemon-reload             # Reload after editing the unit file
+```
+
+Copyright 2009-2010 by Marcello Perathoner Copyright 2019-present by Project Gutenberg

--- a/README.md
+++ b/README.md
@@ -35,24 +35,20 @@ pip install pipenv
 
 ```bash
 sudo useradd -r -m -d /var/lib/autocat -s /bin/bash autocat
-sudo mkdir -p /var/lib/autocat/autocat3
 sudo mkdir -p /var/lib/autocat/log
 sudo mkdir -p /var/run/autocat
-sudo chown -R autocat:autocat /var/lib/autocat
-sudo chown -R autocat:autocat /var/run/autocat
 ```
 
 ### 3. Clone the repository
 
 ```bash
-git clone https://github.com/zachjesus/autocat3.git /tmp/autocat3
-sudo cp -r /tmp/autocat3/* /var/lib/autocat/autocat3/
-sudo chown -R autocat:autocat /var/lib/autocat
+sudo su - autocat
+git clone https://github.com/gutenbergtools/autocat3.git
 ```
 
 ### 4. Install dependencies
 
-pipenv reads the `Pipfile` and auto-detects Python 3.6 from pyenv. Setting `PIPENV_VENV_IN_PROJECT` puts the virtualenv in `.venv/` inside the project directory so the systemd service can find it.
+pipenv reads the `Pipfile` and auto-detects Python 3.9 from pyenv. Setting `PIPENV_VENV_IN_PROJECT` puts the virtualenv in `.venv/` inside the project directory so the systemd service can find it.
 
 ```bash
 cd /var/lib/autocat/autocat3
@@ -65,40 +61,7 @@ Verify:
 sudo -u autocat /var/lib/autocat/autocat3/.venv/bin/python --version
 ```
 
-### 5. Create the materialized view
-
-Until this is merged officially, the scripts live in [gutenbergtools/pgdb PR #15](https://github.com/gutenbergtools/pgdb/pull/15).
-Clone the repo, check out that PR, and run the scripts against your `gutenberg`
-database. pg_trgm is now managed by its own scripts, so they must be run in
-order, and a few require the `postgres` superuser.
-
-```bash
-git clone https://github.com/gutenbergtools/pgdb.git
-cd pgdb
-git fetch origin pull/15/head:full-mv-patch
-git checkout full-mv-patch
-```
-
-Run these in order:
-
-```bash
-# 1. Prep: drop objects depending on the old (unpackaged) pg_trgm — run as gutenberg
-psql -U gutenberg -d gutenberg -f 15_prep_pg_trgm_install.sql
-
-# 2. Drop leftover unpackaged pg_trgm artifacts — MUST run as the postgres superuser
-psql -U postgres -d gutenberg -f 16_drop_pg_trgm_artifacts.sql
-
-# 3. Install the pg_trgm extension and recreate its indexes — MUST run as postgres
-psql -U postgres -d gutenberg -f 17_install_pg_trgm_extension.sql
-
-# 4. Create the materialized view — run as the same user you will use for pguser
-psql -U gutenberg -d gutenberg -f 18_materialized_view.sql
-```
-
-To avoid permission errors, create the materialized view (step 4) as the same
-user you will be using for `pguser` in the next step.
-
-### 6. Configure
+### 5. Configure
 
 Edit `/etc/autocat3.conf` (or `~/.autocat3` under the autocat user) to override defaults from `CherryPy.conf`. At minimum, set your database credentials and hosts:
 
@@ -120,7 +83,7 @@ mv_refresh_hour: 17
 
 Other information on configuring Autocat3 can be found in configuring.txt
 
-### 7. Install the systemd service
+### 6. Install the systemd service
 
 The service runs the app using the venv's Python directly:
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # autocat3_original
 
-**autocat3** is a Python/CherryPy application that serves dynamic content for [Project Gutenberg](https://www.gutenberg.org). 
+**autocat3** is a python-based application used for supporting [Project Gutenberg](gutenberg.org).
 
-CherryPy is used as the web framwork which is easy to develop.
+CherryPy is used as the web framework which is easy to develop.
 
 It mainly implements the search functionality and rate limiter. Also return results pages based on templates.
 

--- a/Timer.py
+++ b/Timer.py
@@ -18,7 +18,13 @@ Usage:
 
 from __future__ import unicode_literals
 
+import datetime
+import logging
+
+import psycopg2
 import cherrypy
+
+from libgutenberg import GutenbergDatabase
 
 import BaseSearcher
 
@@ -32,10 +38,10 @@ class TimerPlugin (cherrypy.process.plugins.Monitor):
     """
 
     def __init__ (self, bus):
-        # interval in seconds
         frequency = 300
         super (TimerPlugin, self).__init__ (bus, self.tick, frequency)
         self.name = 'timer'
+        self._last_refresh_date = None
 
     def start (self):
         super (TimerPlugin, self).start ()
@@ -49,3 +55,42 @@ class TimerPlugin (cherrypy.process.plugins.Monitor):
             BaseSearcher.books_in_archive = BaseSearcher.sql_get ('select count (*) from books')
         except:
             pass
+
+        refresh_hour = cherrypy.config.get ('mv_refresh_hour', 17)
+        now = datetime.datetime.now ()
+
+        if now.hour == refresh_hour and self._last_refresh_date != now.date ():
+            self._try_refresh_mv ()
+
+    def _try_refresh_mv (self):
+        """ Refresh mv_books_dc, skipping if another instance is already refreshing.
+
+        — Zachary Rosario
+
+        Bypasses the pool to avoid statement timeout errors.
+        pguser needs EXECUTE on refresh_mv_books_dc() and ownership of mv_books_dc.
+        """
+        conn = None
+        try:
+            params = GutenbergDatabase.get_connection_params (cherrypy.config)
+            conn = psycopg2.connect (**params)
+            cur = conn.cursor ()
+
+            # Transaction-level advisory lock keyed on the view's OID.
+            # Auto-releases on commit/rollback no explicit unlock needed.
+            cur.execute ("""
+                SELECT pg_try_advisory_xact_lock(c.oid::bigint)
+                FROM pg_class c WHERE c.relname = 'mv_books_dc'
+            """)
+            if not cur.fetchone ()[0]:
+                return
+
+            cur.execute ("SELECT refresh_mv_books_dc()")
+            conn.commit ()
+            self._last_refresh_date = datetime.datetime.now ().date ()
+            cherrypy.log ("MV refresh completed.", context='TIMER', severity=logging.INFO)
+        except Exception as e:
+            cherrypy.log ("MV refresh failed: %s" % e, context='TIMER', severity=logging.ERROR)
+        finally:
+            if conn:
+                conn.close ()

--- a/autocat3.service
+++ b/autocat3.service
@@ -8,7 +8,7 @@ Type=simple
 RuntimeDirectory=autocat
 WorkingDirectory=/var/lib/autocat/autocat3
 ExecStartPre=-/usr/bin/mkdir -p /var/run/autocat
-ExecStart=/usr/local/bin/pipenv run python CherryPyApp.py
+ExecStart=/var/lib/autocat/autocat3/.venv/bin/python CherryPyApp.py
 LimitNOFILE=infinity
 
 

--- a/mv_search/Search.py
+++ b/mv_search/Search.py
@@ -1,0 +1,922 @@
+"""
+Search.py — Zachary Rosario
+
+Query builder and search interface for the mv_books_dc materialized view.
+"""
+
+import logging
+from typing import Callable, Dict, List, Optional, Tuple, Union
+
+from sqlalchemy import text
+from sqlalchemy.orm import sessionmaker
+
+from .constants import (
+    BOOKSHELF_CATEGORY_PREFIX,
+    Crosswalk,
+    CuratedBookshelves,
+    FileType,
+    Language,
+    LoCCMainClass,
+    OrderBy,
+    SearchField,
+    SearchType,
+    SortDirection,
+)
+from .crosswalks import CROSSWALK_MAP
+
+__all__ = [
+    "FullTextSearch",
+    "SearchQuery",
+]
+
+_FIELD_COLS = {
+    SearchField.BOOK: ("tsvec", "book_text"),
+    SearchField.TITLE: ("to_tsvector('english', title)", "title"),
+    SearchField.AUTHOR: (
+        "to_tsvector('english', array_to_string(creator_names, ' '))",
+        "array_to_string(creator_names, ' ')",
+    ),
+}
+
+_ORDER_COLUMNS = {
+    OrderBy.DOWNLOADS: ("downloads", SortDirection.DESC, None),
+    OrderBy.TITLE: ("title", SortDirection.ASC, None),
+    OrderBy.AUTHOR: ("creator_names[1]", SortDirection.ASC, "LAST"),
+    OrderBy.RELEASE_DATE: ("CAST(release_date AS date)", SortDirection.DESC, "LAST"),
+    OrderBy.RANDOM: ("RANDOM()", None, None),
+}
+
+_SELECT = """book_id, title, downloads, CAST(release_date AS text) AS release_date, copyrighted, lang_codes,
+    creator_ids, creator_names, creator_roles,
+    creator_born_floor, creator_born_ceil, creator_died_floor, creator_died_ceil,
+    subject_ids, subject_names, bookshelf_ids, bookshelf_names,
+    locc_codes, is_audio, dcmitypes, publisher, summary, credits,
+    reading_level, coverpage, format_filenames, format_filetypes,
+    format_hr_filetypes, format_mediatypes, format_extents"""
+
+_SELECT_OPDS_SMALL = """book_id, title, lang_codes,
+    creator_ids, creator_names, creator_roles,
+    format_filenames, format_filetypes, format_hr_filetypes,
+    format_mediatypes, format_extents"""
+
+_SUBQUERY = """book_id, title, downloads, CAST(release_date AS text) AS release_date,
+    copyrighted, lang_codes, is_audio,
+    creator_ids, creator_names, creator_roles,
+    creator_born_floor, creator_born_ceil, creator_died_floor, creator_died_ceil,
+    subject_ids, subject_names, bookshelf_ids, bookshelf_names,
+    dcmitypes, publisher, summary, credits, reading_level,
+    coverpage, format_filenames, format_filetypes, format_hr_filetypes,
+    format_mediatypes, format_extents,
+    max_author_birthyear, min_author_birthyear,
+    max_author_deathyear, min_author_deathyear,
+    locc_codes,
+    tsvec, book_text"""
+
+
+# =============================================================================
+# SearchQuery
+# =============================================================================
+
+
+class SearchQuery:
+    def __init__(self):
+        self._search = []  # type: List[Tuple[str, Dict, str]]
+        self._filters = []  # type: List[Tuple[str, Dict]]
+        self._order = OrderBy.DOWNLOADS
+        self._sort_dir = None  # type: Optional[SortDirection]
+        self._page = 1
+        self._page_size = 25
+        self._crosswalk = Crosswalk.PG
+        self._param_counter = 0
+        self._also_downloaded_for = None  # type: Optional[int]
+
+    def __getitem__(self, key: Union[int, Tuple]) -> "SearchQuery":
+        """Set pagination: q[3] for page 3, q[2, 50] for page 2 with 50 results."""
+        if isinstance(key, tuple):
+            self._page = max(1, int(key[0]))
+            self._page_size = max(1, min(100, int(key[1])))
+        else:
+            self._page = max(1, int(key))
+        return self
+
+    def crosswalk(self, cw: Crosswalk) -> "SearchQuery":
+        self._crosswalk = cw
+        return self
+
+    def order_by(
+        self, order: OrderBy, direction: Optional[SortDirection] = None
+    ) -> "SearchQuery":
+        self._order = order
+        self._sort_dir = direction
+        return self
+
+    def _new_param(self, value: object) -> Tuple[str, Dict]:
+        pname = f"__p{self._param_counter}"
+        self._param_counter += 1
+        return pname, {pname: value}
+
+    def filter(self, sql_template: str, *values: object) -> "SearchQuery":
+        params = {}  # type: Dict
+        placeholders = []  # type: List[str]
+        for v in values:
+            pname, p = self._new_param(v)
+            params.update(p)
+            placeholders.append(f":{pname}")
+        sql = sql_template.format(*placeholders)
+        self._filters.append((sql, params))
+        return self
+
+    def search(
+        self,
+        txt: str,
+        field: SearchField = SearchField.BOOK,
+        search_type: SearchType = SearchType.FTS,
+    ) -> "SearchQuery":
+        txt = (txt or "").strip()
+        if not txt:
+            return self
+
+        fts_col, text_col = _FIELD_COLS[field]
+        pname, p = self._new_param(txt)
+
+        if search_type == SearchType.FUZZY:
+            self._search.append((f":{pname} <% {text_col}", p, text_col))
+        elif search_type == SearchType.HYBRID:
+            sql = f"{fts_col} @@ websearch_to_tsquery('english', :{pname})"
+            self._search.append((sql, p, fts_col, SearchType.HYBRID, text_col))
+        else:
+            sql = f"{fts_col} @@ websearch_to_tsquery('english', :{pname})"
+            self._search.append((sql, p, fts_col))
+        return self
+
+    def _is_hybrid(self) -> bool:
+        return any(len(s) > 3 and s[3] == SearchType.HYBRID for s in self._search)
+
+    def _use_fuzzy(self) -> None:
+        """Switch hybrid clauses from tsvector to trigram search."""
+        updated = []
+        for s in self._search:
+            if len(s) > 3 and s[3] == SearchType.HYBRID:
+                _, p, _, _, text_col = s
+                pname = next(iter(p))
+                updated.append((f":{pname} <% {text_col}", p, text_col))
+            else:
+                updated.append(s)
+        self._search = updated
+
+    # Filter Methods
+
+    def etext(self, nr: int) -> "SearchQuery":
+        return self.filter(
+            """
+            book_id = {}
+            """,
+            int(nr),
+        )
+
+    def etexts(self, nrs: List[int]) -> "SearchQuery":
+        return self.filter(
+            """
+            book_id = ANY({})
+            """,
+            [int(n) for n in nrs],
+        )
+
+    def downloads_gte(self, n: int) -> "SearchQuery":
+        return self.filter(
+            """
+            downloads >= {}
+            """,
+            int(n),
+        )
+
+    def downloads_lte(self, n: int) -> "SearchQuery":
+        return self.filter(
+            """
+            downloads <= {}
+            """,
+            int(n),
+        )
+
+    def public_domain(self) -> "SearchQuery":
+        self._filters.append(("copyrighted = 0", {}))
+        return self
+
+    def copyrighted(self) -> "SearchQuery":
+        self._filters.append(("copyrighted = 1", {}))
+        return self
+
+    def lang(self, code: Union[Language, str]) -> "SearchQuery":
+        if isinstance(code, Language):
+            code_val = code.code
+        else:
+            code_val = code.lower()
+        return self.filter(
+            """
+            lang_codes @> ARRAY[CAST({} AS text)]
+            """,
+            code_val,
+        )
+
+    def text_only(self) -> "SearchQuery":
+        self._filters.append(("is_audio = false", {}))
+        return self
+
+    def audiobook(self) -> "SearchQuery":
+        self._filters.append(("is_audio = true", {}))
+        return self
+
+    def author_born_after(self, year: int) -> "SearchQuery":
+        return self.filter(
+            """
+            max_author_birthyear >= {}
+            """,
+            int(year),
+        )
+
+    def author_born_before(self, year: int) -> "SearchQuery":
+        return self.filter(
+            """
+            min_author_birthyear <= {}
+            """,
+            int(year),
+        )
+
+    def author_died_after(self, year: int) -> "SearchQuery":
+        return self.filter(
+            """
+            max_author_deathyear >= {}
+            """,
+            int(year),
+        )
+
+    def author_died_before(self, year: int) -> "SearchQuery":
+        return self.filter(
+            """
+            min_author_deathyear <= {}
+            """,
+            int(year),
+        )
+
+    def released_after(self, date: str) -> "SearchQuery":
+        return self.filter(
+            """
+            CAST(release_date AS date) >= CAST({} AS date)
+            """,
+            str(date),
+        )
+
+    def released_before(self, date: str) -> "SearchQuery":
+        return self.filter(
+            """
+            CAST(release_date AS date) <= CAST({} AS date)
+            """,
+            str(date),
+        )
+        
+    def locc(self, code: Union[LoCCMainClass, str]) -> "SearchQuery":
+        if isinstance(code, LoCCMainClass):
+            code = code.code
+        else:
+            code = str(code).upper()
+
+        return self.filter(
+            """
+            EXISTS (
+                SELECT 1
+                FROM mn_books_loccs mbl
+                JOIN loccs lc ON lc.pk = mbl.fk_loccs
+                WHERE mbl.fk_books = book_id
+                  AND lc.pk = {}
+            )
+            """,
+            code,
+        )
+
+    def contributor_role(self, role: str) -> "SearchQuery":
+        return self.filter(
+            """
+            EXISTS (
+                SELECT 1
+                FROM mn_books_authors mba
+                JOIN roles r ON mba.fk_roles = r.pk
+                WHERE mba.fk_books = book_id
+                  AND r.role = {}
+            )
+            """,
+            role,
+        )
+
+    def file_type(self, ft: Union[FileType, str]) -> "SearchQuery":
+        if isinstance(ft, FileType):
+            ft_value = ft.value
+        else:
+            ft_value = str(ft)
+
+        return self.filter(
+            """
+            EXISTS (
+                SELECT 1
+                FROM files f
+                JOIN filetypes ft ON f.fk_filetypes = ft.pk
+                WHERE f.fk_books = book_id
+                  AND f.obsoleted = 0
+                  AND f.diskstatus = 0
+                  AND ft.mediatype = {}
+            )
+            """,
+            ft_value,
+        )
+
+    def author_id(self, aid: int) -> "SearchQuery":
+        return self.filter(
+            """
+            EXISTS (
+                SELECT 1
+                FROM mn_books_authors mba
+                WHERE mba.fk_books = book_id
+                  AND mba.fk_authors = {}
+            )
+            """,
+            int(aid),
+        )
+
+    def subject_id(self, sid: int) -> "SearchQuery":
+        return self.filter(
+            """
+            EXISTS (
+                SELECT 1
+                FROM mn_books_subjects mbs
+                WHERE mbs.fk_books = book_id
+                  AND mbs.fk_subjects = {}
+            )
+            """,
+            int(sid),
+        )
+
+    def bookshelf_id(self, bid: int) -> "SearchQuery":
+        return self.filter(
+            """
+            EXISTS (
+                SELECT 1
+                FROM mn_books_bookshelves mbb
+                WHERE mbb.fk_books = book_id
+                  AND mbb.fk_bookshelves = {}
+            )
+            """,
+            int(bid),
+        )
+
+    def also_downloaded(self, book_id: int) -> "SearchQuery":
+        """Books co-downloaded with the given ebook (scores.also_downloads)."""
+        self._also_downloaded_for = int(book_id)
+        return self
+
+    def where(self, sql: str, **params) -> "SearchQuery":
+        """Add raw SQL filter condition. BE CAREFUL WHEN USING!"""
+        for k in params.keys():
+            if k.startswith("__p"):
+                raise ValueError(
+                    "Parameter name reserved by search engine: starts with '__p'"
+                )
+        self._filters.append((sql, params))
+        return self
+
+    # === SQL Building ===
+
+    def _params(self) -> Dict[str, object]:
+        params = {}
+        for _, p, *_ in self._search:
+            params.update(p)
+        for _, p in self._filters:
+            params.update(p)
+        return params
+
+    def _order_sql(self, params: Dict) -> str:
+        if self._order == OrderBy.RELEVANCE and self._search:
+            sql, p, col = self._search[-1][:3]
+            val = next(iter(p.values())) if p else ""
+            params["rank_q"] = str(val).replace("%", "")
+            if "<%" in sql:
+                return f"word_similarity(:rank_q, {col}) DESC, downloads DESC"
+            return f"ts_rank_cd({col}, websearch_to_tsquery('english', :rank_q)) DESC, downloads DESC"
+
+        if self._order == OrderBy.RANDOM:
+            return "RANDOM()"
+
+        if self._order not in _ORDER_COLUMNS:
+            return "downloads DESC"
+
+        col, default_dir, nulls = _ORDER_COLUMNS[self._order]
+        direction = self._sort_dir or default_dir
+        clause = f"{col} {direction.value.upper()}"
+        if nulls:
+            clause += f" NULLS {nulls}"
+        return clause
+
+    def _where_parts(self) -> Tuple[Optional[str], Optional[str]]:
+        search_sql = " AND ".join(s[0] for s in self._search) if self._search else None
+        filter_sql = " AND ".join(f[0] for f in self._filters) if self._filters else None
+        return search_sql, filter_sql
+
+    def _where_sql(self, param_prefix: str = "") -> Tuple[str, Dict]:
+        """WHERE clause and bind params (for facet CTEs)."""
+        params = self._params()
+        search_sql, filter_sql = self._where_parts()
+        where_parts = [p for p in (search_sql, filter_sql) if p]
+        if not where_parts:
+            return "", dict(params)
+
+        if param_prefix:
+            mapping = {old: f"{param_prefix}{old}" for old in params}
+            new_params = {mapping[k]: v for k, v in params.items()}
+            remapped_parts = []
+            for part in where_parts:
+                s = part
+                for old in sorted(mapping, key=len, reverse=True):
+                    s = s.replace(f":{old}", f":{mapping[old]}")
+                remapped_parts.append(s)
+            return f"WHERE {' AND '.join(remapped_parts)}", new_params
+
+        return f"WHERE {' AND '.join(where_parts)}", dict(params)
+
+    def _result_select(self) -> str:
+        if self._crosswalk == Crosswalk.OPDS_SMALL:
+            return _SELECT_OPDS_SMALL
+        return _SELECT
+
+    def build(self, *, with_count: bool = False) -> Tuple[str, Dict]:
+        params = self._params()
+        limit, offset = self._page_size, (self._page - 1) * self._page_size
+        total_col = ", COUNT(*) OVER() AS total_count" if with_count else ""
+        select_cols = self._result_select()
+
+        if self._also_downloaded_for is not None:
+            params["__also_dl_for"] = self._also_downloaded_for
+            sql = (
+                f"SELECT {select_cols}{total_col} FROM ("
+                " SELECT r.fk_books AS pk, sum(r.cnt) AS dl"
+                " FROM (SELECT id FROM scores.also_downloads"
+                " WHERE fk_books = :__also_dl_for) sessions"
+                " CROSS JOIN LATERAL ("
+                " SELECT fk_books, count(*)::bigint AS cnt"
+                " FROM scores.also_downloads"
+                " WHERE id = sessions.id"
+                " AND fk_books != :__also_dl_for"
+                " GROUP BY fk_books"
+                " ) r GROUP BY r.fk_books"
+                ") d JOIN mv_books_dc ON book_id = d.pk"
+                " ORDER BY d.dl DESC"
+                f" LIMIT {limit} OFFSET {offset}"
+            )
+            return sql, params
+
+        order = self._order_sql(params)
+        search_sql, filter_sql = self._where_parts()
+
+        if search_sql and filter_sql:
+            sql = (
+                f"SELECT {select_cols}{total_col} FROM (SELECT {_SUBQUERY} FROM mv_books_dc WHERE {search_sql}) t "
+                f"WHERE {filter_sql} ORDER BY {order} LIMIT {limit} OFFSET {offset}"
+            )
+        elif search_sql:
+            sql = (
+                f"SELECT {select_cols}{total_col} FROM mv_books_dc WHERE {search_sql} "
+                f"ORDER BY {order} LIMIT {limit} OFFSET {offset}"
+            )
+        elif filter_sql:
+            sql = (
+                f"SELECT {select_cols}{total_col} FROM mv_books_dc WHERE {filter_sql} "
+                f"ORDER BY {order} LIMIT {limit} OFFSET {offset}"
+            )
+        else:
+            sql = (
+                f"SELECT {select_cols}{total_col} FROM mv_books_dc "
+                f"ORDER BY {order} LIMIT {limit} OFFSET {offset}"
+            )
+
+        return sql, params
+
+    def build_count(self) -> Tuple[str, Dict]:
+        params = self._params()
+        if self._also_downloaded_for is not None:
+            params["__also_dl_for"] = self._also_downloaded_for
+            return (
+                "SELECT COUNT(*) FROM ("
+                " SELECT r.fk_books AS pk"
+                " FROM (SELECT id FROM scores.also_downloads"
+                " WHERE fk_books = :__also_dl_for) sessions"
+                " CROSS JOIN LATERAL ("
+                " SELECT fk_books"
+                " FROM scores.also_downloads"
+                " WHERE id = sessions.id"
+                " AND fk_books != :__also_dl_for"
+                " GROUP BY fk_books"
+                " ) r GROUP BY r.fk_books"
+                ") d"
+            ), params
+
+        search_sql, filter_sql = self._where_parts()
+
+        if search_sql and filter_sql:
+            return (
+                "SELECT COUNT(*) FROM (SELECT book_id, lang_codes, downloads, copyrighted,"
+                " is_audio, max_author_birthyear, min_author_birthyear,"
+                " max_author_deathyear, min_author_deathyear, release_date"
+                f" FROM mv_books_dc WHERE {search_sql}) t WHERE {filter_sql}",
+                params,
+            )
+        elif search_sql:
+            return f"SELECT COUNT(*) FROM mv_books_dc WHERE {search_sql}", params
+        elif filter_sql:
+            return f"SELECT COUNT(*) FROM mv_books_dc WHERE {filter_sql}", params
+        return "SELECT COUNT(*) FROM mv_books_dc", params
+
+
+# =============================================================================
+# FullTextSearch
+# =============================================================================
+
+
+class FullTextSearch:
+    """Main search interface."""
+
+    def __init__(self, engine):
+        self.engine = engine
+        self.Session = sessionmaker(bind=self.engine)
+        self._bookshelf_ids = None
+
+    def query(self, crosswalk: Crosswalk = Crosswalk.PG) -> "SearchQuery":
+        """Create a new query builder."""
+        q = SearchQuery()
+        q._crosswalk = crosswalk
+        return q
+
+    def _transform(self, row, cw: Crosswalk) -> Dict:
+        return CROSSWALK_MAP[cw](row)
+
+    def execute(self, q: "SearchQuery", with_count: bool = True) -> Dict:
+        """Execute query and return paginated results.
+
+        with_count=False skips the window total ('total' comes back None);
+        use it for preview feeds that don't paginate.
+        """
+        with self.Session() as session:
+            sql, params = q.build(with_count=with_count)
+            rows = session.execute(text(sql), params).fetchall()
+            if q._is_hybrid() and not rows:
+                q._use_fuzzy()
+                sql, params = q.build(with_count=with_count)
+                rows = session.execute(text(sql), params).fetchall()
+
+        if with_count:
+            total = rows[0].total_count if rows else 0
+            total_pages = max(1, (total + q._page_size - 1) // q._page_size)
+        else:
+            total = None
+            total_pages = 1
+
+        return {
+            "results": [self._transform(r, q._crosswalk) for r in rows],
+            "page": q._page,
+            "page_size": q._page_size,
+            "total": total,
+            "total_pages": total_pages,
+        }
+
+    def count(self, q: "SearchQuery") -> int:
+        """Count results without fetching."""
+        with self.Session() as session:
+            sql, params = q.build_count()
+            return session.execute(text(sql), params).scalar() or 0
+
+    def bookshelf_ids(self) -> Dict[str, int]:
+        """Map of bookshelf name -> primary key, loaded once and cached.
+
+        Bookshelf rows are static for a given dataset, so curated shelves can
+        reference shelves by name and resolve to ids here instead of carrying
+        hard-coded primary keys.
+        """
+        if self._bookshelf_ids is None:
+            with self.Session() as session:
+                rows = session.execute(
+                    text("SELECT pk, bookshelf FROM bookshelves")
+                ).fetchall()
+            self._bookshelf_ids = {r.bookshelf: r.pk for r in rows}
+        return self._bookshelf_ids
+
+    def curated_shelves(self, cat: CuratedBookshelves) -> List[Tuple[int, str]]:
+        """Resolve a curated category to (shelf_id, label) pairs.
+
+        Labels missing from the current dataset are skipped.
+        """
+        ids = self.bookshelf_ids()
+        resolved = []
+        for label in cat.shelf_names:
+            pk = ids.get(BOOKSHELF_CATEGORY_PREFIX + label)
+            if pk is not None:
+                resolved.append((pk, label))
+        return resolved
+
+    def list_bookshelves(self) -> List[Dict]:
+        """
+        List all bookshelves with book counts.
+
+        Returns:
+            List of dicts with 'id', 'name', and 'book_count' keys
+        """
+        sql = """
+            SELECT
+                bs.pk AS id,
+                bs.bookshelf AS name,
+                COUNT(mbbs.fk_books) AS book_count
+            FROM bookshelves bs
+            LEFT JOIN mn_books_bookshelves mbbs
+                ON bs.pk = mbbs.fk_bookshelves
+            GROUP BY
+                bs.pk,
+                bs.bookshelf
+            ORDER BY
+                bs.bookshelf
+        """
+        with self.Session() as session:
+            rows = session.execute(text(sql)).fetchall()
+            return [
+                {"id": r.id, "name": r.name, "book_count": r.book_count} for r in rows
+            ]
+
+    def list_subjects(self) -> List[Dict]:
+        """
+        List all subjects with book counts.
+
+        Returns:
+            List of dicts with 'id', 'name', and 'book_count' keys
+        """
+        sql = """
+            SELECT
+                s.pk AS id,
+                s.subject AS name,
+                COUNT(mbs.fk_books) AS book_count
+            FROM subjects s
+            LEFT JOIN mn_books_subjects mbs
+                ON s.pk = mbs.fk_subjects
+            GROUP BY
+                s.pk,
+                s.subject
+            HAVING
+                COUNT(mbs.fk_books) > 0
+            ORDER BY
+                book_count DESC,
+                s.subject
+        """
+        with self.Session() as session:
+            rows = session.execute(text(sql)).fetchall()
+            return [
+                {"id": r.id, "name": r.name, "book_count": r.book_count} for r in rows
+            ]
+
+    def get_subject_name(self, subject_id: int) -> Optional[str]:
+        """
+        Get a single subject's name by ID (fast lookup).
+
+        Args:
+            subject_id: Subject primary key
+
+        Returns:
+            Subject name or None if not found
+        """
+        sql = """
+            SELECT
+                subject
+            FROM subjects
+            WHERE pk = :id
+        """
+        with self.Session() as session:
+            result = session.execute(text(sql), {"id": subject_id}).scalar()
+            return result
+
+    def get_facets_for_query(
+        self,
+        subject_q: "SearchQuery",
+        language_q: Optional["SearchQuery"] = None,
+        *,
+        subject_limit: Optional[int] = None,
+        language_limit: Optional[int] = None,
+        include_subjects: bool = True,
+        include_languages: bool = True,
+    ) -> Dict[str, List[Dict]]:
+        """Subject and language facets in one round-trip.
+
+        subject_q includes active lang (if any), not subject_id.
+        language_q includes subject_id (if any), not lang.
+        """
+        if not include_subjects and not include_languages:
+            return {"subjects": [], "languages": []}
+
+        if language_q is None:
+            language_q = subject_q
+
+        sub_where, sub_params = subject_q._where_sql()
+        lang_where, lang_params = language_q._where_sql()
+        dual_base = sub_where != lang_where or sub_params != lang_params
+        if dual_base and include_languages:
+            lang_where, lang_params = language_q._where_sql("lq_")
+
+        params = {}
+        if include_subjects:
+            params.update(sub_params)
+        if include_languages:
+            params.update(lang_params)
+        cte_parts = []
+        subject_from = ""
+        language_from = ""
+
+        if include_subjects and include_languages and not dual_base:
+            cte_parts.append(
+                f"""matched_books AS (
+                SELECT book_id, lang_codes
+                FROM mv_books_dc
+                {sub_where}
+            )"""
+            )
+            subject_from = language_from = "matched_books mb"
+        else:
+            if include_subjects:
+                cte_parts.append(
+                    f"""subject_books AS (
+                    SELECT book_id
+                    FROM mv_books_dc
+                    {sub_where}
+                )"""
+                )
+                subject_from = "subject_books mb"
+            if include_languages:
+                cte_parts.append(
+                    f"""language_books AS (
+                    SELECT book_id, lang_codes
+                    FROM mv_books_dc
+                    {lang_where}
+                )"""
+                )
+                language_from = "language_books mb"
+
+        subject_limit_clause = ""
+        if subject_limit is not None:
+            params["subject_limit"] = max(1, int(subject_limit))
+            subject_limit_clause = "LIMIT :subject_limit"
+
+        language_limit_clause = ""
+        if language_limit is not None:
+            params["language_limit"] = max(1, int(language_limit))
+            language_limit_clause = "LIMIT :language_limit"
+
+        parts = []
+        if include_subjects:
+            parts.append(
+                f"""(
+                SELECT
+                    'subject' AS facet,
+                    s.pk::text AS key,
+                    s.subject AS label,
+                    COUNT(*) AS count
+                FROM {subject_from}
+                JOIN mn_books_subjects mbs
+                    ON mbs.fk_books = mb.book_id
+                JOIN subjects s
+                    ON s.pk = mbs.fk_subjects
+                GROUP BY
+                    s.pk,
+                    s.subject
+                ORDER BY
+                    count DESC
+                {subject_limit_clause}
+            )"""
+            )
+        if include_languages:
+            parts.append(
+                f"""(
+                SELECT
+                    'language' AS facet,
+                    lang AS key,
+                    NULL::text AS label,
+                    COUNT(*) AS count
+                FROM {language_from},
+                    unnest(mb.lang_codes) AS lang
+                GROUP BY
+                    lang
+                ORDER BY
+                    count DESC
+                {language_limit_clause}
+            )"""
+            )
+
+        sql = f"""
+            WITH {", ".join(cte_parts)}
+            {" UNION ALL ".join(parts)}
+        """
+
+        subjects = []
+        languages = []
+        with self.Session() as session:
+            for row in session.execute(text(sql), params).fetchall():
+                if row.facet == "subject":
+                    subjects.append(
+                        {"id": int(row.key), "name": row.label, "count": row.count}
+                    )
+                else:
+                    languages.append({"code": row.key, "count": row.count})
+
+        return {"subjects": subjects, "languages": languages}
+
+    def get_opds_facets(
+        self,
+        scope_fn: Callable[["SearchQuery"], "SearchQuery"],
+        lang: str = "",
+        subject_id: Optional[int] = None,
+        *,
+        subject_limit: int = 10,
+        include_subjects: bool = True,
+    ) -> Dict[str, Optional[List[Dict]]]:
+        """OPDS facet counts in one query.
+
+        Subjects use scope + lang; languages use scope + subject_id.
+        """
+        try:
+            subject_q = scope_fn(self.query())
+            if include_subjects and lang:
+                subject_q.lang(lang)
+            language_q = scope_fn(self.query())
+            if subject_id is not None:
+                language_q.subject_id(subject_id)
+            data = self.get_facets_for_query(
+                subject_q,
+                language_q,
+                subject_limit=subject_limit,
+                include_subjects=include_subjects,
+            )
+            subjects = data["subjects"] if include_subjects else None
+            if include_subjects and subject_id is not None and subjects is not None:
+                if not any(s["id"] == subject_id for s in subjects):
+                    name = self.get_subject_name(subject_id)
+                    if name:
+                        pin_q = scope_fn(self.query())
+                        if lang:
+                            pin_q.lang(lang)
+                        pin_q.subject_id(subject_id)
+                        subjects = [
+                            {
+                                "id": subject_id,
+                                "name": name,
+                                "count": self.count(pin_q),
+                            },
+                            *subjects,
+                        ][:subject_limit]
+            return {
+                "subjects": subjects,
+                "languages": data["languages"],
+            }
+        except Exception:
+            logging.getLogger(__name__).exception("OPDS facet query failed")
+            return {"subjects": None, "languages": None}
+
+    def get_locc_children(self, parent: Union[LoCCMainClass, str]) -> List[Dict]:
+        """Return LoCC children for parent."""
+        if isinstance(parent, LoCCMainClass):
+            parent_code = parent.code
+        else:
+            parent_code = (parent or "").strip().upper()
+
+        if not parent_code:
+            sorted_classes = sorted(LoCCMainClass, key=lambda x: x.code)
+            return [
+                {"code": item.code, "label": item.label}
+                for item in sorted_classes
+            ]
+
+        if len(parent_code) != 1:
+            return []
+
+        sql = text(
+            """
+            SELECT
+                lc.pk AS code,
+                lc.locc AS label
+            FROM loccs lc
+            WHERE lc.pk LIKE :pattern
+              AND lc.pk != :parent
+              AND EXISTS (
+                SELECT 1
+                FROM mn_books_loccs mbl
+                WHERE mbl.fk_loccs = lc.pk
+              )
+            ORDER BY
+                char_length(lc.pk),
+                lc.pk
+            """
+        )
+
+        with self.Session() as session:
+            rows = session.execute(
+                sql, {"pattern": f"{parent_code}%", "parent": parent_code}
+            ).mappings().all()
+            return [{"code": r["code"], "label": r["label"]} for r in rows]

--- a/mv_search/Search.py
+++ b/mv_search/Search.py
@@ -43,6 +43,7 @@ _ORDER_COLUMNS = {
     OrderBy.TITLE: ("title", SortDirection.ASC, None),
     OrderBy.AUTHOR: ("creator_names[1]", SortDirection.ASC, "LAST"),
     OrderBy.RELEASE_DATE: ("CAST(release_date AS date)", SortDirection.DESC, "LAST"),
+    OrderBy.FILEMTIME: ("filemtime", SortDirection.DESC, "LAST"),
     OrderBy.RANDOM: ("RANDOM()", None, None),
 }
 
@@ -273,7 +274,15 @@ class SearchQuery:
             """,
             str(date),
         )
-        
+
+    def modified_after(self, date: str) -> "SearchQuery":
+        return self.filter(
+            """
+            CAST(filemtime AS date) >= CAST({} AS date)
+            """,
+            str(date),
+        )
+
     def locc(self, code: Union[LoCCMainClass, str]) -> "SearchQuery":
         if isinstance(code, LoCCMainClass):
             code = code.code

--- a/mv_search/constants.py
+++ b/mv_search/constants.py
@@ -1,0 +1,316 @@
+"""
+constants.py — Zachary Rosario
+
+Enums and constants for the mv_books_dc search module.
+"""
+
+from enum import Enum
+from typing import Tuple
+
+__all__ = [
+    "FileType",
+    "SearchType",
+    "SearchField",
+    "OrderBy",
+    "SortDirection",
+    "Crosswalk",
+    "Language",
+    "LoCCMainClass",
+    "CuratedBookshelves",
+    "BOOKSHELF_CATEGORY_PREFIX",
+]
+
+# Curated shelves live in the `bookshelves` table as "Category: <label>" rows.
+BOOKSHELF_CATEGORY_PREFIX = "Category: "
+
+
+class FileType(str, Enum):
+    EPUB = "application/epub+zip"
+    KINDLE = "application/x-mobipocket-ebook"
+    PDF = "application/pdf"
+    TXT = "text/plain"
+    HTML = "text/html"
+
+
+class SearchType(str, Enum):
+    FTS = "fts"
+    FUZZY = "fuzzy"
+    HYBRID = "hybrid"
+
+
+class SearchField(str, Enum):
+    BOOK = "book"
+    TITLE = "title"
+    AUTHOR = "author"
+
+
+class OrderBy(str, Enum):
+    """Sort options."""
+
+    RELEVANCE = "relevance"
+    DOWNLOADS = "downloads"
+    TITLE = "title"
+    AUTHOR = "author"
+    RELEASE_DATE = "release_date"
+    RANDOM = "random"
+
+
+class SortDirection(str, Enum):
+    ASC = "asc"
+    DESC = "desc"
+
+
+class Crosswalk(str, Enum):
+    PG = "pg"
+    OPDS = "opds"
+    OPDS_SMALL = "opds_small"
+
+
+class Language(Enum):
+    EN = ("en", "English")
+    AF = ("af", "Afrikaans")
+    ALE = ("ale", "Aleut")
+    ANG = ("ang", "Old English")
+    AR = ("ar", "Arabic")
+    ARP = ("arp", "Arapaho")
+    BG = ("bg", "Bulgarian")
+    BGS = ("bgs", "Basa Banyumasan")
+    BO = ("bo", "Tibetan")
+    BR = ("br", "Breton")
+    BRX = ("brx", "Bodo")
+    CA = ("ca", "Catalan")
+    CEB = ("ceb", "Cebuano")
+    CS = ("cs", "Czech")
+    CSB = ("csb", "Kashubian")
+    CY = ("cy", "Welsh")
+    DA = ("da", "Danish")
+    DE = ("de", "German")
+    EL = ("el", "Greek")
+    ENM = ("enm", "Middle English")
+    EO = ("eo", "Esperanto")
+    ES = ("es", "Spanish")
+    ET = ("et", "Estonian")
+    FA = ("fa", "Persian")
+    FI = ("fi", "Finnish")
+    FR = ("fr", "French")
+    FUR = ("fur", "Friulian")
+    FY = ("fy", "Western Frisian")
+    GA = ("ga", "Irish")
+    GL = ("gl", "Galician")
+    GLA = ("gla", "Scottish Gaelic")
+    GRC = ("grc", "Ancient Greek")
+    HAI = ("hai", "Haida")
+    HE = ("he", "Hebrew")
+    HU = ("hu", "Hungarian")
+    IA = ("ia", "Interlingua")
+    ILO = ("ilo", "Iloko")
+    IS = ("is", "Icelandic")
+    IT = ("it", "Italian")
+    IU = ("iu", "Inuktitut")
+    JA = ("ja", "Japanese")
+    KHA = ("kha", "Khasi")
+    KLD = ("kld", "Klamath-Modoc")
+    KO = ("ko", "Korean")
+    LA = ("la", "Latin")
+    LT = ("lt", "Lithuanian")
+    MI = ("mi", "Māori")
+    MYN = ("myn", "Mayan Languages")
+    NAH = ("nah", "Nahuatl")
+    NAI = ("nai", "North American Indian")
+    NAP = ("nap", "Neapolitan")
+    NAV = ("nav", "Navajo")
+    NL = ("nl", "Dutch")
+    NO = ("no", "Norwegian")
+    OC = ("oc", "Occitan")
+    OJI = ("oji", "Ojibwa")
+    PL = ("pl", "Polish")
+    PT = ("pt", "Portuguese")
+    RMQ = ("rmq", "Romani")
+    RO = ("ro", "Romanian")
+    RU = ("ru", "Russian")
+    SA = ("sa", "Sanskrit")
+    SCO = ("sco", "Scots")
+    SL = ("sl", "Slovenian")
+    SR = ("sr", "Serbian")
+    SV = ("sv", "Swedish")
+    TE = ("te", "Telugu")
+    TL = ("tl", "Tagalog")
+    YI = ("yi", "Yiddish")
+    ZH = ("zh", "Chinese")
+
+    @property
+    def code(self) -> str:
+        return self.value[0]
+
+    @property
+    def label(self) -> str:
+        return self.value[1]
+
+
+class LoCCMainClass(Enum):
+    A = ("A", "General Works")
+    B = ("B", "Philosophy, Psychology, Religion")
+    C = ("C", "History: Auxiliary Sciences")
+    D = ("D", "History: General and Eastern Hemisphere")
+    E = ("E", "History: America")
+    F = ("F", "History: America (Local)")
+    G = ("G", "Geography, Anthropology, Recreation")
+    H = ("H", "Social Sciences")
+    J = ("J", "Political Science")
+    K = ("K", "Law")
+    L = ("L", "Education")
+    M = ("M", "Music")
+    N = ("N", "Fine Arts")
+    P = ("P", "Language and Literatures")
+    Q = ("Q", "Science")
+    R = ("R", "Medicine")
+    S = ("S", "Agriculture")
+    T = ("T", "Technology")
+    U = ("U", "Military Science")
+    V = ("V", "Naval Science")
+    Z = ("Z", "Bibliography, Library Science")
+
+    @property
+    def code(self) -> str:
+        return self.value[0]
+
+    @property
+    def label(self) -> str:
+        return self.value[1]
+
+
+class CuratedBookshelves(Enum):
+    """Curated groupings of Project Gutenberg "Category: ..." bookshelves.
+
+    Shelves are referenced by their display label only; the matching
+    `bookshelves` row is "Category: <label>" and its primary key is resolved
+    from the database on first use (see FullTextSearch.curated_shelves). The
+    ids are stable for a given dataset but are not hard-coded here so a
+    rebuild can't silently point a label at the wrong shelf.
+    """
+
+    LITERATURE = (
+        "Literature",
+        (
+            "Adventure",
+            "American Literature",
+            "British Literature",
+            "French Literature",
+            "German Literature",
+            "Russian Literature",
+            "Classics of Literature",
+            "Biographies",
+            "Novels",
+            "Short Stories",
+            "Poetry",
+            "Plays/Films/Dramas",
+            "Romance",
+            "Science-Fiction & Fantasy",
+            "Crime, Thrillers and Mystery",
+            "Mythology, Legends & Folklore",
+            "Humour",
+            "Children & Young Adult Reading",
+            "Literature - Other",
+        ),
+    )
+    SCIENCE_TECHNOLOGY = (
+        "Science & Technology",
+        (
+            "Engineering & Technology",
+            "Mathematics",
+            "Science - Physics",
+            "Science - Chemistry/Biochemistry",
+            "Science - Biology",
+            "Science - Earth/Agricultural/Farming",
+            "Research Methods/Statistics/Information Sys",
+            "Environmental Issues",
+        ),
+    )
+    HISTORY = (
+        "History",
+        (
+            "History - American",
+            "History - British",
+            "History - European",
+            "History - Ancient",
+            "History - Medieval/Middle Ages",
+            "History - Early Modern (c. 1450-1750)",
+            "History - Modern (1750+)",
+            "History - Religious",
+            "History - Royalty",
+            "History - Warfare",
+            "History - Schools & Universities",
+            "History - Other",
+            "Archaeology & Anthropology",
+        ),
+    )
+    SOCIAL_SCIENCES_SOCIETY = (
+        "Social Sciences & Society",
+        (
+            "Business/Management",
+            "Economics",
+            "Law & Criminology",
+            "Gender & Sexuality Studies",
+            "Psychiatry/Psychology",
+            "Sociology",
+            "Politics",
+            "Parenthood & Family Relations",
+            "Old Age & the Elderly",
+        ),
+    )
+    ARTS_CULTURE = (
+        "Arts & Culture",
+        (
+            "Art",
+            "Architecture",
+            "Music",
+            "Fashion",
+            "Journalism/Media/Writing",
+            "Language & Communication",
+            "Essays, Letters & Speeches",
+        ),
+    )
+    RELIGION_PHILOSOPHY = (
+        "Religion & Philosophy",
+        (
+            "Religion/Spirituality",
+            "Philosophy & Ethics",
+        ),
+    )
+    LIFESTYLE_HOBBIES = (
+        "Lifestyle & Hobbies",
+        (
+            "Cooking & Drinking",
+            "Sports/Hobbies",
+            "How To ...",
+            "Travel Writing",
+            "Nature/Gardening/Animals",
+            "Sexuality & Erotica",
+        ),
+    )
+    HEALTH_MEDICINE = (
+        "Health & Medicine",
+        (
+            "Health & Medicine",
+            "Drugs/Alcohol/Pharmacology",
+            "Nutrition",
+        ),
+    )
+    EDUCATION_REFERENCE = (
+        "Education & Reference",
+        (
+            "Encyclopedias/Dictionaries/Reference",
+            "Teaching & Education",
+            "Reports & Conference Proceedings",
+            "Journals",
+        ),
+    )
+
+    @property
+    def genre(self) -> str:
+        return self.value[0]
+
+    @property
+    def shelf_names(self) -> Tuple[str, ...]:
+        """Display labels for this category's shelves."""
+        return self.value[1]

--- a/mv_search/constants.py
+++ b/mv_search/constants.py
@@ -52,6 +52,7 @@ class OrderBy(str, Enum):
     TITLE = "title"
     AUTHOR = "author"
     RELEASE_DATE = "release_date"
+    FILEMTIME = "filemtime"
     RANDOM = "random"
 
 

--- a/mv_search/crosswalks.py
+++ b/mv_search/crosswalks.py
@@ -49,14 +49,37 @@ def _rights_text(copyrighted: Optional[int]) -> str:
     )
 
 
-def _gutenberg_url(path: str) -> str:
-    """Build full Gutenberg URL from a path, preserving absolute URLs."""
+def _abs_url(base: str, path: str) -> str:
     if not path:
         return ""
     if path.startswith(("http://", "https://")):
         return path
-    base = cherrypy.config.get("document_root", "https://www.gutenberg.org").rstrip("/")
-    return f"{base}{path if path.startswith('/') else '/' + path}"
+    return f"{base.rstrip('/')}{path if path.startswith('/') else '/' + path}"
+
+
+def _gutenberg_url(path: str) -> str:
+    """Absolute URL for files/covers (always file_host, usually gutenberg.org)."""
+    host = cherrypy.config.get("file_host", "www.gutenberg.org")
+    if host.startswith(("http://", "https://")):
+        base = host
+    else:
+        base = f"https://{host}"
+    return _abs_url(base, path)
+
+
+def _catalog_url(path: str) -> str:
+    """Absolute URL for OPDS routes (this server: localhost in dev, prod host in prod)."""
+    try:
+        base = cherrypy.request.base
+    except AttributeError:
+        base = ""
+    if not base:
+        host = cherrypy.config.get("host", "www.gutenberg.org")
+        if host.startswith(("http://", "https://")):
+            base = host
+        else:
+            base = f"https://{host}"
+    return _abs_url(base, path)
 
 
 def _build_creators(row) -> List[Dict[str, Any]]:
@@ -202,7 +225,7 @@ def _build_opds_contributor_entry(
         )
         contributor["links"] = [
             {
-                "href": _gutenberg_url(f"/opds/search?author_id={person['id']}"),
+                "href": _catalog_url(f"/opds/search?author_id={person['id']}"),
                 "type": _OPDS_FEED_TYPE,
             }
         ]
@@ -267,7 +290,7 @@ def _opds_bookshelf_subject_metadata(
             "code": str(shelf_id),
             "links": [
                 {
-                    "href": _gutenberg_url(f"/opds/bookshelves?id={shelf_id}"),
+                    "href": _catalog_url(f"/opds/bookshelves?id={shelf_id}"),
                     "type": _OPDS_FEED_TYPE,
                 }
             ],
@@ -288,7 +311,7 @@ def _opds_subject_metadata(
             subj["code"] = str(s["id"])
             subj["links"] = [
                 {
-                    "href": _gutenberg_url(f"/opds/subjects?id={s['id']}"),
+                    "href": _catalog_url(f"/opds/subjects?id={s['id']}"),
                     "type": _OPDS_FEED_TYPE,
                 }
             ]
@@ -304,7 +327,7 @@ def _opds_subject_metadata(
             "code": code,
             "links": [
                 {
-                    "href": _gutenberg_url(f"/opds/search?locc={code}"),
+                    "href": _catalog_url(f"/opds/search?locc={code}"),
                     "type": _OPDS_FEED_TYPE,
                 }
             ],
@@ -315,7 +338,7 @@ def _opds_subject_metadata(
 def _opds_self_link(book_id) -> Dict[str, str]:
     return {
         "rel": "self",
-        "href": _gutenberg_url(f"/opds/publications?id={book_id}"),
+        "href": _catalog_url(f"/opds/publications?id={book_id}"),
         "type": _OPDS_PUBLICATION_TYPE,
     }
 
@@ -352,7 +375,7 @@ def _opds_acquisition_links(
 def _opds_also_link(book_id) -> Dict[str, str]:
     return {
         "rel": "related",
-        "href": _gutenberg_url(f"/opds/also?id={book_id}"),
+        "href": _catalog_url(f"/opds/also?id={book_id}"),
         "type": _OPDS_FEED_TYPE,
         "title": "Readers also downloaded",
     }

--- a/mv_search/crosswalks.py
+++ b/mv_search/crosswalks.py
@@ -8,6 +8,8 @@ import html
 from typing import Any, Dict, List, Optional
 from itertools import zip_longest
 
+import cherrypy
+
 from .constants import BOOKSHELF_CATEGORY_PREFIX, Crosswalk, Language, LoCCMainClass
 from .formatters import format_dict_result, ContributorFormat
 
@@ -53,7 +55,8 @@ def _gutenberg_url(path: str) -> str:
         return ""
     if path.startswith(("http://", "https://")):
         return path
-    return f"https://www.gutenberg.org/{path.lstrip('/')}"
+    base = cherrypy.config.get("document_root", "https://www.gutenberg.org").rstrip("/")
+    return f"{base}{path if path.startswith('/') else '/' + path}"
 
 
 def _build_creators(row) -> List[Dict[str, Any]]:
@@ -149,7 +152,7 @@ def _build_formats(row) -> List[Dict[str, Any]]:
 def _opds_book_metadata(row) -> Dict[str, Any]:
     return {
         "@type": "http://schema.org/Book",
-        "identifier": f"https://www.gutenberg.org/ebooks/{row.book_id}",
+        "identifier": _gutenberg_url(f"/ebooks/{row.book_id}"),
         "title": row.title,
         "language": (list(row.lang_codes) if row.lang_codes else ["en"])[0] or "en",
     }
@@ -194,11 +197,14 @@ def _build_opds_contributor_entry(
 ) -> Dict[str, Any]:
     contributor = {"name": person["name"], "sortAs": person["name"]}
     if with_search_link and person.get("id"):
-        contributor["identifier"] = (
-            f"https://www.gutenberg.org/ebooks/author/{person['id']}"
+        contributor["identifier"] = _gutenberg_url(
+            f"/ebooks/author/{person['id']}"
         )
         contributor["links"] = [
-            {"href": f"/opds/search?author_id={person['id']}", "type": _OPDS_FEED_TYPE}
+            {
+                "href": _gutenberg_url(f"/opds/search?author_id={person['id']}"),
+                "type": _OPDS_FEED_TYPE,
+            }
         ]
     return contributor
 
@@ -260,7 +266,10 @@ def _opds_bookshelf_subject_metadata(
             "scheme": SCHEME_GUTENBERG_BOOKSHELF,
             "code": str(shelf_id),
             "links": [
-                {"href": f"/opds/bookshelves?id={shelf_id}", "type": _OPDS_FEED_TYPE}
+                {
+                    "href": _gutenberg_url(f"/opds/bookshelves?id={shelf_id}"),
+                    "type": _OPDS_FEED_TYPE,
+                }
             ],
         })
     return subject_objs
@@ -278,7 +287,10 @@ def _opds_subject_metadata(
             subj["scheme"] = SCHEME_GUTENBERG_SUBJECT
             subj["code"] = str(s["id"])
             subj["links"] = [
-                {"href": f"/opds/subjects?id={s['id']}", "type": _OPDS_FEED_TYPE}
+                {
+                    "href": _gutenberg_url(f"/opds/subjects?id={s['id']}"),
+                    "type": _OPDS_FEED_TYPE,
+                }
             ]
         subject_objs.append(subj)
     for code in locc_codes:
@@ -290,7 +302,12 @@ def _opds_subject_metadata(
             "sortAs": code,
             "scheme": SCHEME_LCC,
             "code": code,
-            "links": [{"href": f"/opds/search?locc={code}", "type": _OPDS_FEED_TYPE}],
+            "links": [
+                {
+                    "href": _gutenberg_url(f"/opds/search?locc={code}"),
+                    "type": _OPDS_FEED_TYPE,
+                }
+            ],
         })
     return subject_objs
 
@@ -298,7 +315,7 @@ def _opds_subject_metadata(
 def _opds_self_link(book_id) -> Dict[str, str]:
     return {
         "rel": "self",
-        "href": f"/opds/publications?id={book_id}",
+        "href": _gutenberg_url(f"/opds/publications?id={book_id}"),
         "type": _OPDS_PUBLICATION_TYPE,
     }
 
@@ -327,7 +344,7 @@ def _opds_acquisition_links(
             return [link]
     return [{
         "rel": "http://opds-spec.org/acquisition/open-access",
-        "href": f"https://www.gutenberg.org/ebooks/{book_id}",
+        "href": _gutenberg_url(f"/ebooks/{book_id}"),
         "type": "text/html",
     }]
 
@@ -335,7 +352,7 @@ def _opds_acquisition_links(
 def _opds_also_link(book_id) -> Dict[str, str]:
     return {
         "rel": "related",
-        "href": f"/opds/also?id={book_id}",
+        "href": _gutenberg_url(f"/opds/also?id={book_id}"),
         "type": _OPDS_FEED_TYPE,
         "title": "Readers also downloaded",
     }

--- a/mv_search/crosswalks.py
+++ b/mv_search/crosswalks.py
@@ -1,0 +1,475 @@
+"""
+crosswalks.py — Zachary Rosario
+
+Row-to-dict transforms for PG and OPDS 2.0 output formats.
+"""
+
+import html
+from typing import Any, Dict, List, Optional
+from itertools import zip_longest
+
+from .constants import BOOKSHELF_CATEGORY_PREFIX, Crosswalk, Language, LoCCMainClass
+from .formatters import format_dict_result, ContributorFormat
+
+_LOCC_LABELS = {item.code: item.label for item in LoCCMainClass}
+
+LANGUAGE_LABELS = {lang.code: lang.label for lang in Language}
+
+# Readium Web Publication Manifest subject schemes
+SCHEME_LCC = "http://purl.org/dc/terms/LCC"
+SCHEME_GUTENBERG_SUBJECT = "https://www.gutenberg.org/ebooks/subject/"
+SCHEME_GUTENBERG_BOOKSHELF = "https://www.gutenberg.org/ebooks/bookshelf/"
+
+_OPDS_FEED_TYPE = "application/opds+json"
+_OPDS_PUBLICATION_TYPE = "application/opds-publication+json"
+
+# PG-generated cover JPEGs (fixed output sizes from ebookconverter)
+_COVER_SPECS = (
+    ("cover.medium", 200, 288, "http://opds-spec.org/image"),
+    ("cover.small", 66, 95, "http://opds-spec.org/image/thumbnail"),
+)
+_ACQUISITION_FORMATS = (
+    "epub3.images",
+    "epub.images",
+    "epub.noimages",
+    "kindle.images",
+    "pdf.images",
+    "pdf.noimages",
+    "html",
+)
+
+
+def _rights_text(copyrighted: Optional[int]) -> str:
+    return (
+        "Copyrighted. Read the copyright notice inside this book for details."
+        if copyrighted
+        else "Public domain in the USA."
+    )
+
+
+def _gutenberg_url(path: str) -> str:
+    """Build full Gutenberg URL from a path, preserving absolute URLs."""
+    if not path:
+        return ""
+    if path.startswith(("http://", "https://")):
+        return path
+    return f"https://www.gutenberg.org/{path.lstrip('/')}"
+
+
+def _build_creators(row) -> List[Dict[str, Any]]:
+    names = list(row.creator_names) if row.creator_names else []
+    roles = list(row.creator_roles) if row.creator_roles else []
+    ids = list(row.creator_ids) if row.creator_ids else []
+    born_floors = list(row.creator_born_floor) if row.creator_born_floor else []
+    born_ceils = list(row.creator_born_ceil) if row.creator_born_ceil else []
+    died_floors = list(row.creator_died_floor) if row.creator_died_floor else []
+    died_ceils = list(row.creator_died_ceil) if row.creator_died_ceil else []
+    creators = []
+    for name, role, cid, bf, bc, df, dc in zip_longest(
+        names, roles, ids, born_floors, born_ceils, died_floors, died_ceils, fillvalue=None
+    ):
+        if not name:
+            continue
+        creators.append({
+            "id": cid,
+            "name": name,
+            "role": role,
+            "born_floor": bf,
+            "born_ceil": bc,
+            "died_floor": df,
+            "died_ceil": dc,
+        })
+    return creators
+
+
+def _build_subjects(row) -> List[Dict[str, Any]]:
+    names = list(row.subject_names) if row.subject_names else []
+    ids = list(row.subject_ids) if row.subject_ids else []
+    return [
+        {"id": sid, "subject": name}
+        for name, sid in zip_longest(names, ids, fillvalue=None)
+        if name
+    ]
+
+
+def _build_bookshelves(row) -> List[Dict[str, Any]]:
+    names = list(row.bookshelf_names) if row.bookshelf_names else []
+    ids = list(row.bookshelf_ids) if row.bookshelf_ids else []
+    return [
+        {"id": bid, "bookshelf": name}
+        for name, bid in zip_longest(names, ids, fillvalue=None)
+        if name
+    ]
+
+
+def _build_cover_formats(row) -> List[Dict[str, Any]]:
+    filenames = list(row.format_filenames) if row.format_filenames else []
+    filetypes = list(row.format_filetypes) if row.format_filetypes else []
+    mediatypes = list(row.format_mediatypes) if row.format_mediatypes else []
+    return [
+        {"filename": fn, "filetype": ftype, "mediatype": med}
+        for fn, ftype, med in zip_longest(filenames, filetypes, mediatypes, fillvalue=None)
+        if fn
+    ]
+
+
+def _build_creators_slim(row) -> List[Dict[str, Any]]:
+    names = list(row.creator_names) if row.creator_names else []
+    roles = list(row.creator_roles) if row.creator_roles else []
+    ids = list(row.creator_ids) if row.creator_ids else []
+    return [
+        {"id": cid, "name": name, "role": role}
+        for name, role, cid in zip_longest(names, roles, ids, fillvalue=None)
+        if name
+    ]
+
+
+def _build_formats(row) -> List[Dict[str, Any]]:
+    filenames = list(row.format_filenames) if row.format_filenames else []
+    filetypes = list(row.format_filetypes) if row.format_filetypes else []
+    hr_filetypes = list(row.format_hr_filetypes) if row.format_hr_filetypes else []
+    mediatypes = list(row.format_mediatypes) if row.format_mediatypes else []
+    extents = list(row.format_extents) if row.format_extents else []
+    results = []
+    for fn, ftype, hr, med, extent in zip_longest(
+        filenames, filetypes, hr_filetypes, mediatypes, extents, fillvalue=None
+    ):
+        if not fn:
+            continue
+        results.append({
+            "filename": fn,
+            "filetype": ftype,
+            "hr_filetype": hr,
+            "mediatype": med,
+            "extent": extent,
+        })
+    return results
+
+
+def _opds_book_metadata(row) -> Dict[str, Any]:
+    return {
+        "@type": "http://schema.org/Book",
+        "identifier": f"https://www.gutenberg.org/ebooks/{row.book_id}",
+        "title": row.title,
+        "language": (list(row.lang_codes) if row.lang_codes else ["en"])[0] or "en",
+    }
+
+
+def _opds_accessibility() -> Dict[str, Any]:
+    return {
+        "hazard": ["none"],
+        "accessMode": ["textual"],
+        "accessModeSufficient": [["textual"]],
+        "feature": ["displayTransformability", "unlocked"],
+    }
+
+
+# Readium Web Publication Manifest contributor fields.
+# creator_roles in mv_books_dc uses full MARC relator labels (e.g. "Author",
+# "Illustrator"). Roles without a direct WPM field map to "contributor".
+_OPDS_ROLE_FIELDS = {
+    "author": "author",
+    "creator": "author",
+    "dubious author": "author",
+    "translator": "translator",
+    "editor": "editor",
+    "artist": "artist",
+    "illustrator": "illustrator",
+    "letterer": "letterer",
+    "penciler": "penciler",
+    "colorist": "colorist",
+    "inker": "inker",
+}
+
+
+def _opds_role_field(role: Optional[str]) -> str:
+    """Map a mv_books_dc creator_roles label to a WPM metadata field."""
+    if not role:
+        return "contributor"
+    return _OPDS_ROLE_FIELDS.get(role.strip().lower(), "contributor")
+
+
+def _build_opds_contributor_entry(
+    person: Dict[str, Any], *, with_search_link: bool = False
+) -> Dict[str, Any]:
+    contributor = {"name": person["name"], "sortAs": person["name"]}
+    if with_search_link and person.get("id"):
+        contributor["identifier"] = (
+            f"https://www.gutenberg.org/ebooks/author/{person['id']}"
+        )
+        contributor["links"] = [
+            {"href": f"/opds/search?author_id={person['id']}", "type": _OPDS_FEED_TYPE}
+        ]
+    return contributor
+
+
+def _set_publication_contributors(
+    publication_metadata: Dict[str, Any],
+    creators: List[Dict[str, Any]],
+    *,
+    with_search_link: bool = False,
+) -> None:
+    grouped: Dict[str, List[Dict[str, Any]]] = {}
+    for person in creators:
+        if not person.get("name"):
+            continue
+        field = _opds_role_field(person.get("role"))
+        grouped.setdefault(field, []).append(
+            _build_opds_contributor_entry(person, with_search_link=with_search_link)
+        )
+
+    for field, entries in grouped.items():
+        publication_metadata[field] = entries[0] if len(entries) == 1 else entries
+
+
+def _opds_description(row, creators, formatter: ContributorFormat) -> Optional[str]:
+    desc_parts = []
+    if creators:
+        desc_parts.append(
+            f"Creators: {formatter(all=True, strunk_join=True, pretty=True, dates=True, show_role=True)}"
+        )
+    summary = (list(row.summary) if row.summary else [None])[0]
+    if summary:
+        desc_parts.append(summary)
+    credits = (list(row.credits) if row.credits else [None])[0]
+    if credits:
+        desc_parts.append(f"Credits: {credits}")
+    if row.reading_level:
+        desc_parts.append(f"Reading Level: {row.reading_level}")
+    dcmitype = [t for t in (list(row.dcmitypes) if row.dcmitypes else []) if t]
+    if dcmitype:
+        desc_parts.append(f"Category: {', '.join(dcmitype)}")
+    desc_parts.append(f"Rights: {_rights_text(row.copyrighted)}")
+    desc_parts.append(f"Downloads: {row.downloads}")
+    if not desc_parts:
+        return None
+    return "<p>" + "</p><p>".join(html.escape(p) for p in desc_parts) + "</p>"
+
+
+def _opds_bookshelf_subject_metadata(
+    bookshelves: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    subject_objs = []
+    for b in bookshelves:
+        name = b.get("bookshelf")
+        shelf_id = b.get("id")
+        if not name or shelf_id is None:
+            continue
+        subject_objs.append({
+            "name": name.removeprefix(BOOKSHELF_CATEGORY_PREFIX),
+            "scheme": SCHEME_GUTENBERG_BOOKSHELF,
+            "code": str(shelf_id),
+            "links": [
+                {"href": f"/opds/bookshelves?id={shelf_id}", "type": _OPDS_FEED_TYPE}
+            ],
+        })
+    return subject_objs
+
+
+def _opds_subject_metadata(
+    raw_subjects: List[Dict[str, Any]], locc_codes: List[str]
+) -> List[Dict[str, Any]]:
+    subject_objs = []
+    for s in raw_subjects:
+        if not s.get("subject"):
+            continue
+        subj = {"name": s["subject"]}
+        if s.get("id") is not None:
+            subj["scheme"] = SCHEME_GUTENBERG_SUBJECT
+            subj["code"] = str(s["id"])
+            subj["links"] = [
+                {"href": f"/opds/subjects?id={s['id']}", "type": _OPDS_FEED_TYPE}
+            ]
+        subject_objs.append(subj)
+    for code in locc_codes:
+        main_class = code[0].upper() if code else ""
+        label = _LOCC_LABELS.get(main_class, "")
+        name = f"{label}: {code}" if label else code
+        subject_objs.append({
+            "name": name,
+            "sortAs": code,
+            "scheme": SCHEME_LCC,
+            "code": code,
+            "links": [{"href": f"/opds/search?locc={code}", "type": _OPDS_FEED_TYPE}],
+        })
+    return subject_objs
+
+
+def _opds_self_link(book_id) -> Dict[str, str]:
+    return {
+        "rel": "self",
+        "href": f"/opds/publications?id={book_id}",
+        "type": _OPDS_PUBLICATION_TYPE,
+    }
+
+
+def _opds_acquisition_links(
+    formats: List[Dict[str, Any]], book_id
+) -> List[Dict[str, Any]]:
+    for try_format in _ACQUISITION_FORMATS:
+        for f in formats:
+            fn = f.get("filename")
+            if not fn:
+                continue
+            ftype = (f.get("filetype") or "").strip().lower()
+            if ftype != try_format:
+                continue
+            mtype = (f.get("mediatype") or "").strip()
+            link = {
+                "rel": "http://opds-spec.org/acquisition/open-access",
+                "href": _gutenberg_url(fn),
+                "type": mtype or "application/epub+zip",
+            }
+            if f.get("extent") is not None and f["extent"] > 0:
+                link["length"] = f["extent"]
+            if f.get("hr_filetype"):
+                link["title"] = f["hr_filetype"]
+            return [link]
+    return [{
+        "rel": "http://opds-spec.org/acquisition/open-access",
+        "href": f"https://www.gutenberg.org/ebooks/{book_id}",
+        "type": "text/html",
+    }]
+
+
+def _opds_also_link(book_id) -> Dict[str, str]:
+    return {
+        "rel": "related",
+        "href": f"/opds/also?id={book_id}",
+        "type": _OPDS_FEED_TYPE,
+        "title": "Readers also downloaded",
+    }
+
+
+def _opds_cover_images(formats: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    formats_by_type = {
+        (f.get("filetype") or "").strip(): f
+        for f in formats
+        if f.get("filename") and (f.get("filetype") or "").strip()
+    }
+    images = []
+    for filetype, width, height, rel in _COVER_SPECS:
+        f = formats_by_type.get(filetype)
+        if not f:
+            continue
+        mtype = (f.get("mediatype") or "").strip() or "image/jpeg"
+        images.append({
+            "href": _gutenberg_url(f["filename"]),
+            "type": mtype,
+            "width": width,
+            "height": height,
+            "rel": rel,
+        })
+    return images
+
+
+def _opds_row_parts(row):
+    """Shared row parsing for OPDS crosswalks."""
+    creators = _build_creators(row)
+    formats = _build_formats(row)
+    return {
+        "creators": creators,
+        "formats": formats,
+        "raw_subjects": _build_subjects(row),
+        "bookshelves": _build_bookshelves(row),
+        "locc_codes": [c for c in (list(row.locc_codes) if row.locc_codes else []) if c],
+        "formatter": ContributorFormat(creators),
+    }
+
+
+@format_dict_result
+def crosswalk_pg(row) -> Dict[str, Any]:
+    creators = _build_creators(row)
+    subjects = [s["subject"] for s in _build_subjects(row) if s.get("subject")]
+    bookshelves = [b["bookshelf"] for b in _build_bookshelves(row) if b.get("bookshelf")]
+    language = [
+        {"code": code, "name": LANGUAGE_LABELS.get(code, code)}
+        for code in (list(row.lang_codes) if row.lang_codes else [])
+        if code
+    ]
+    formats = _build_formats(row)
+
+    formatter = ContributorFormat(creators)
+
+    return {
+        "ebook_no": row.book_id,
+        "title": row.title,
+        "contributors": creators,
+        "language": language,
+        "subjects": subjects,
+        "bookshelves": bookshelves,
+        "release_date": row.release_date,
+        "downloads_last_30_days": row.downloads,
+        "files": [
+            {"filename": f.get("filename"), "type": f.get("mediatype"), "size": f.get("extent")}
+            for f in formats if f.get("filename")
+        ],
+        "cover_url": (list(row.coverpage) if row.coverpage else [None])[0],
+        "format": formatter,
+    }
+
+
+@format_dict_result
+def crosswalk_opds_small(row) -> Dict[str, Any]:
+    """Compact OPDS publication for catalog/search/browse lists."""
+    publication_metadata = _opds_book_metadata(row)
+    _set_publication_contributors(publication_metadata, _build_creators_slim(row))
+
+    links = [_opds_self_link(row.book_id)]
+    links.extend(_opds_acquisition_links(_build_formats(row), row.book_id))
+
+    result = {
+        "metadata": publication_metadata,
+        "links": links,
+    }
+    images = _opds_cover_images(_build_cover_formats(row))
+    if images:
+        result["images"] = images
+    return result
+
+
+@format_dict_result
+def crosswalk_opds(row) -> Dict[str, Any]:
+    """Full OPDS publication for /opds/publications detail."""
+    parts = _opds_row_parts(row)
+    publication_metadata = _opds_book_metadata(row)
+    publication_metadata["accessibility"] = _opds_accessibility()
+
+    _set_publication_contributors(
+        publication_metadata, parts["creators"], with_search_link=True
+    )
+
+    if row.release_date:
+        publication_metadata["published"] = row.release_date
+
+    description = _opds_description(row, parts["creators"], parts["formatter"])
+    if description:
+        publication_metadata["description"] = description
+
+    subject_objs = (
+        _opds_bookshelf_subject_metadata(parts["bookshelves"])
+        + _opds_subject_metadata(parts["raw_subjects"], parts["locc_codes"])
+    )
+    if subject_objs:
+        publication_metadata["subject"] = subject_objs
+
+    if row.publisher:
+        publication_metadata["publisher"] = row.publisher
+
+    links = [_opds_self_link(row.book_id)]
+    links.extend(_opds_acquisition_links(parts["formats"], row.book_id))
+    links.append(_opds_also_link(row.book_id))
+
+    result = {"metadata": publication_metadata, "links": links}
+    images = _opds_cover_images(parts["formats"])
+    if images:
+        result["images"] = images
+
+    return result
+
+
+CROSSWALK_MAP = {
+    Crosswalk.PG: crosswalk_pg,
+    Crosswalk.OPDS: crosswalk_opds,
+    Crosswalk.OPDS_SMALL: crosswalk_opds_small,
+}

--- a/mv_search/crosswalks.py
+++ b/mv_search/crosswalks.py
@@ -68,17 +68,12 @@ def _gutenberg_url(path: str) -> str:
 
 
 def _catalog_url(path: str) -> str:
-    """Absolute URL for OPDS routes (this server: localhost in dev, prod host in prod)."""
-    try:
-        base = cherrypy.request.base
-    except AttributeError:
-        base = ""
-    if not base:
-        host = cherrypy.config.get("host", "www.gutenberg.org")
-        if host.startswith(("http://", "https://")):
-            base = host
-        else:
-            base = f"https://{host}"
+    """Absolute URL for OPDS routes (catalog host from config)."""
+    host = cherrypy.config.get("host", "www.gutenberg.org")
+    if host.startswith(("http://", "https://")):
+        base = host
+    else:
+        base = f"https://{host}"
     return _abs_url(base, path)
 
 

--- a/mv_search/formatters.py
+++ b/mv_search/formatters.py
@@ -1,0 +1,316 @@
+"""
+formatters.py — Zachary Rosario
+
+Formatting helpers based on libgutenberg.DublinCore.
+https://github.com/gutenbergtools/libgutenberg/blob/master/libgutenberg/DublinCore.py
+"""
+
+import re
+from functools import wraps
+from typing import Any, Callable, Dict, List, Optional
+
+_RE_MARC_SUBFIELD = re.compile(r"\$[a-z]")
+_RE_MARC_SPSEP = re.compile(r"[\n ](,|:)([A-Za-z0-9])")
+_RE_CURLY_SINGLE = re.compile("[\u2018\u2019]")  # ' '
+_RE_CURLY_DOUBLE = re.compile("[\u201c\u201d]")  # " "
+_RE_TITLE_SPLITTER = re.compile(r"\s*[;:]\s*")
+_RE_PARENS = re.compile(r"\(.*\)")
+_RE_MULTI_SPACE = re.compile(r"\s+")
+_RE_UPDATED = re.compile(
+    r"\s*[Uu]pdated?:\s*.*$"
+)  # Strip "Updated:" and everything after
+
+_FIELDS_TO_FORMAT = frozenset(
+    {
+        "title",  # Book title
+        "name",  # Contributor names (from authors table)
+        "publisher",  # MARC 260/264
+        "summary",  # MARC 520
+        "credits",  # MARC 508
+        "reading_level",  # MARC 908
+        "subject",  # Individual subject string
+        "subjects",  # List of subjects (parent key)
+        "bookshelf",  # Individual bookshelf string
+        "bookshelves",  # List of bookshelves (parent key)
+    }
+)
+
+
+def strip_marc_subfields(text: str) -> str:
+    """Strip MARC subfield markers ($a, $b, etc)."""
+    if not text or not isinstance(text, str):
+        return ""
+    text = _RE_MARC_SUBFIELD.sub("", text)
+    text = _RE_MARC_SPSEP.sub(r"\1 \2", text)
+    return text.strip()
+
+
+def normalize_text(text: str) -> str:
+    """Straighten curly quotes, normalize title separators."""
+    if not text or not isinstance(text, str):
+        return ""
+    text = _RE_CURLY_SINGLE.sub("'", text)
+    text = _RE_CURLY_DOUBLE.sub('"', text)
+    text = _RE_TITLE_SPLITTER.sub(": ", text)
+    return text.rstrip(": ").strip()
+
+
+def strip_updated(text: str) -> str:
+    """Strip 'Updated:' and everything after from credits (MARC 508)."""
+    if not text or not isinstance(text, str):
+        return ""
+    return _RE_UPDATED.sub("", text).strip()
+
+
+def format_field(key: str, value: str, fields: frozenset = _FIELDS_TO_FORMAT) -> str:
+    """Format a single field value."""
+    if not value or not isinstance(value, str):
+        return ""
+    if key in fields:
+        value = strip_marc_subfields(value)
+        value = normalize_text(value)
+    # Credits field: strip "Updated:" and everything after
+    if key == "credits":
+        value = strip_updated(value)
+    return value.strip()
+
+
+def format_dict(d: Dict, fields: frozenset = _FIELDS_TO_FORMAT) -> Dict:
+    """Recursively format dict values."""
+    result = {}
+    for key, value in d.items():
+        if isinstance(value, str):
+            result[key] = format_field(key, value, fields)
+        elif isinstance(value, dict):
+            result[key] = format_dict(value, fields)
+        elif isinstance(value, list):
+            result[key] = format_list(key, value, fields)
+        else:
+            result[key] = value
+    return result
+
+
+def format_list(
+    parent_key: str, lst: List, fields: frozenset = _FIELDS_TO_FORMAT
+) -> List:
+    """Recursively format list items."""
+    result = []
+    for item in lst:
+        if isinstance(item, dict):
+            result.append(format_dict(item, fields))
+        elif isinstance(item, str):
+            result.append(format_field(parent_key, item, fields))
+        elif isinstance(item, list):
+            result.append(format_list(parent_key, item, fields))
+        else:
+            result.append(item)
+    return result
+
+
+def format_dict_result(
+    fn: Optional[Callable] = None, *, fields_to_format: frozenset = _FIELDS_TO_FORMAT
+) -> Callable:
+    """Decorator that formats dict results."""
+    fields_fs = frozenset(fields_to_format)
+
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        def wrapper(*args, **kwargs) -> Any:
+            result = func(*args, **kwargs)
+            if isinstance(result, dict):
+                return format_dict(result, fields_fs)
+            return result
+
+        return wrapper
+
+    if fn is None:
+        return decorator
+    return decorator(fn)
+
+
+def strunk(items: List[str]) -> str:
+    """
+    Join list with Oxford comma: ["Tom", "Dick", "Harry"] -> "Tom, Dick, and Harry"
+    """
+    if not items:
+        return ""
+    if len(items) == 1:
+        return items[0]
+    if len(items) == 2:
+        return f"{items[0]} and {items[1]}"
+    return f"{', '.join(items[:-1])}, and {items[-1]}"
+
+
+def _format_date_range(floor: Optional[int], ceil: Optional[int]) -> str:
+    """Format birth/death date with uncertainty."""
+    if ceil and not floor:
+        if ceil < 0:
+            return f"{abs(ceil - 1)}? BCE"
+        return f"{ceil}?"
+    if not floor:
+        return ""
+    if ceil and floor != ceil:
+        d = max(floor, ceil)
+        if d < 0:
+            return f"{abs(d - 1)}? BCE"
+        return f"{d}?"
+    if floor < 0:
+        return f"{abs(floor - 1)} BCE"
+    return str(floor)
+
+
+def _reverse_name(name: str) -> str:
+    """Reverse 'Twain, Mark' -> 'Mark Twain'."""
+    if not name:
+        return ""
+    rev = " ".join(reversed(name.split(", ")))
+    rev = _RE_PARENS.sub("", rev)
+    rev = _RE_MULTI_SPACE.sub(" ", rev)
+    return rev.strip()
+
+
+def format_contributor(
+    name: str,
+    role: Optional[str] = None,
+    born_floor: Optional[int] = None,
+    born_ceil: Optional[int] = None,
+    died_floor: Optional[int] = None,
+    died_ceil: Optional[int] = None,
+    *,
+    pretty: bool = False,
+    dates: bool = True,
+    show_role: bool = True,
+) -> str:
+    """
+    Centralized contributor formatting with options.
+
+    Args:
+        name: Contributor name (e.g. "Twain, Mark")
+        role: Role (e.g. "Author", "Editor")
+        born_floor/ceil: Birth date range
+        died_floor/ceil: Death date range
+        pretty: If True, reverse name to "Mark Twain" style
+        dates: If True, include birth-death dates
+        show_role: If True, show role in brackets (if not Author/Creator)
+
+    Examples:
+        format_contributor("Twain, Mark", "Author", 1835, 1835, 1910, 1910)
+            -> "Twain, Mark, 1835-1910"
+
+        format_contributor("Twain, Mark", "Editor", 1835, 1835, 1910, 1910, show_role=True)
+            -> "Twain, Mark, 1835-1910 [Editor]"
+
+        format_contributor("Twain, Mark", "Author", 1835, 1835, 1910, 1910, pretty=True)
+            -> "Mark Twain (1835-1910)"
+
+        format_contributor("Twain, Mark", "Editor", pretty=True, dates=False, show_role=True)
+            -> "Mark Twain [Editor]"
+    """
+    if not name:
+        return ""
+
+    # Name formatting
+    display_name = _reverse_name(name) if pretty else name
+
+    # Date formatting
+    date_str = ""
+    if dates:
+        born = _format_date_range(born_floor, born_ceil)
+        died = _format_date_range(died_floor, died_ceil)
+        if born and died:
+            date_str = f"{born}-{died}"
+        elif born:
+            date_str = f"{born}-"
+        elif died:
+            date_str = f"d. {died}"
+
+    # Role formatting (skip if Author/Creator)
+    role_str = ""
+    if show_role and role and role.lower() not in ("author", "creator", "aut", "cre"):
+        role_str = role
+
+    # Combine based on style
+    if pretty:
+        # Pretty style: "Mark Twain (1835-1910) [Editor]"
+        result = display_name
+        if date_str:
+            result += f" ({date_str})"
+        if role_str:
+            result += f" [{role_str}]"
+    else:
+        # Formal style: "Twain, Mark, 1835-1910 [Editor]"
+        result = display_name
+        if date_str:
+            result += f", {date_str}"
+        if role_str:
+            result += f" [{role_str}]"
+
+    return result
+
+
+def format_contributor_dict(contributor: Dict, **kwargs) -> str:
+    return format_contributor(
+        name=contributor.get("name", ""),
+        role=contributor.get("role"),
+        born_floor=contributor.get("born_floor"),
+        born_ceil=contributor.get("born_ceil"),
+        died_floor=contributor.get("died_floor"),
+        died_ceil=contributor.get("died_ceil"),
+        **kwargs,
+    )
+
+
+class ContributorFormat:
+    """
+    Simple wrapper to format contributors.
+
+    Usage:
+        fmt = book["format"]
+        fmt()                              # main author: "Twain, Mark, 1835-1910"
+        fmt(pretty=True)                   # main author: "Mark Twain (1835-1910)"
+        fmt(all=True)                      # all: "Twain, Mark, 1835-1910; Doe, Jane [Editor]"
+        fmt(all=True, pretty=True)         # all: "Mark Twain (1835-1910); Jane Doe [Editor]"
+        fmt(all=True, strunk=True)         # all: "Mark Twain, Jane Doe, and John Smith"
+    """
+
+    def __init__(self, contributors: List[Dict]):
+        self._c = contributors
+
+    def __call__(
+        self,
+        *,
+        all: bool = False,
+        sep: str = "; ",
+        strunk_join: bool = False,
+        pretty: bool = False,
+        dates: bool = True,
+        show_role: bool = True,
+    ) -> str:
+        """
+        Format contributor(s).
+
+        Args:
+            all: If True, format all contributors. If False (default), just main/first.
+            sep: Separator when all=True and strunk_join=False (default "; ")
+            strunk_join: If True, use Oxford comma "and" style instead of sep
+            pretty: "Mark Twain" style vs "Twain, Mark" formal
+            dates: Include birth-death dates
+            show_role: Show role in brackets (if not Author)
+        """
+        if all:
+            formatted = [
+                format_contributor_dict(
+                    c, pretty=pretty, dates=dates, show_role=show_role
+                )
+                for c in self._c
+                if c.get("name")
+            ]
+            if strunk_join:
+                return strunk(formatted)
+            return sep.join(formatted)
+        # Main/first author only
+        if self._c:
+            return format_contributor_dict(
+                self._c[0], pretty=pretty, dates=dates, show_role=show_role
+            )
+        return ""

--- a/mv_search/test_search.py
+++ b/mv_search/test_search.py
@@ -1,0 +1,456 @@
+"""
+test_search.py — integration tests for the mv_books_dc search module.
+
+Run: python3 -m unittest mv_search.test_search -v
+"""
+
+import os
+import unittest
+
+import cherrypy
+from sqlalchemy import create_engine
+
+from .constants import (
+    Crosswalk,
+    FileType,
+    Language,
+    LoCCMainClass,
+    OrderBy,
+    SearchField,
+    SearchType,
+)
+from .Search import FullTextSearch
+from .crosswalks import _set_publication_contributors
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TEST_CONF = os.path.join(ROOT, "test.conf")
+
+
+def _make_search() -> FullTextSearch:
+    cherrypy.config.update(TEST_CONF)
+    c = cherrypy.config
+    engine = create_engine(
+        f"postgresql://{c['pguser']}@{c['pghost']}:{c['pgport']}/{c['pgdatabase']}"
+    )
+    return FullTextSearch(engine)
+
+
+class SearchTestBase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.s = _make_search()
+
+    def _run(self, query, expect_results=True):
+        data = self.s.execute(query)
+        if expect_results:
+            self.assertGreater(data["total"], 0, data)
+            self.assertTrue(data["results"])
+        else:
+            self.assertEqual(data["total"], 0, data)
+        return data
+
+
+class SearchTypeTests(SearchTestBase):
+    def test_search_types(self):
+        cases = (
+            ("FTS BOOK", self.s.query().search("Shakespeare")[1, 10], True),
+            (
+                "FUZZY BOOK",
+                self.s.query().search("Frankenstien", search_type=SearchType.FUZZY)[
+                    1, 10
+                ],
+                True,
+            ),
+            (
+                "HYBRID BOOK (exact)",
+                self.s.query().search("Shakespeare", search_type=SearchType.HYBRID)[
+                    1, 10
+                ],
+                True,
+            ),
+            (
+                "HYBRID BOOK (typo)",
+                self.s.query().search("Frankenstien", search_type=SearchType.HYBRID)[
+                    1, 10
+                ],
+                True,
+            ),
+            ("FTS typo (no hit)", self.s.query().search("Frankenstien")[1, 10], False),
+        )
+        for name, query, expect in cases:
+            with self.subTest(name=name):
+                self._run(query, expect_results=expect)
+
+
+class FieldScopedSearchTests(SearchTestBase):
+    def test_field_scoped(self):
+        cases = (
+            ("FTS TITLE", self.s.query().search("Hamlet", field=SearchField.TITLE)[1, 10]),
+            (
+                "FTS AUTHOR",
+                self.s.query().search("Shakespeare", field=SearchField.AUTHOR)[1, 10],
+            ),
+            (
+                "FUZZY TITLE",
+                self.s.query().search(
+                    "Hamlett", field=SearchField.TITLE, search_type=SearchType.FUZZY
+                )[1, 10],
+            ),
+            (
+                "FUZZY AUTHOR",
+                self.s.query().search(
+                    "Shakspeare",
+                    field=SearchField.AUTHOR,
+                    search_type=SearchType.FUZZY,
+                )[1, 10],
+            ),
+            (
+                "HYBRID TITLE (exact)",
+                self.s.query().search(
+                    "Hamlet", field=SearchField.TITLE, search_type=SearchType.HYBRID
+                )[1, 10],
+            ),
+            (
+                "HYBRID AUTHOR (typo)",
+                self.s.query().search(
+                    "Shakspeare",
+                    field=SearchField.AUTHOR,
+                    search_type=SearchType.HYBRID,
+                )[1, 10],
+            ),
+            (
+                "TITLE + AUTHOR (AND)",
+                self.s.query()
+                .search("Romeo", field=SearchField.TITLE)
+                .search("Shakespeare", field=SearchField.AUTHOR)[1, 10],
+            ),
+        )
+        for name, query in cases:
+            with self.subTest(name=name):
+                self._run(query)
+
+
+class PrimaryKeyFilterTests(SearchTestBase):
+    def test_primary_key_filters(self):
+        cases = (
+            ("etext()", self.s.query().etext(1342)[1, 10]),
+            ("etexts()", self.s.query().etexts([1342, 84, 11])[1, 10]),
+        )
+        for name, query in cases:
+            with self.subTest(name=name):
+                self._run(query)
+
+
+class BTreeFilterTests(SearchTestBase):
+    def test_btree_filters(self):
+        cases = (
+            ("downloads_gte()", self.s.query().downloads_gte(10000)[1, 10]),
+            ("downloads_lte()", self.s.query().downloads_lte(100)[1, 10]),
+            ("public_domain()", self.s.query().public_domain()[1, 10]),
+            ("copyrighted()", self.s.query().copyrighted()[1, 10]),
+            ("text_only()", self.s.query().text_only()[1, 10]),
+            ("audiobook()", self.s.query().audiobook()[1, 10]),
+            ("author_born_after()", self.s.query().author_born_after(1900)[1, 10]),
+            ("author_born_before()", self.s.query().author_born_before(1700)[1, 10]),
+        )
+        for name, query in cases:
+            with self.subTest(name=name):
+                self._run(query)
+
+
+class DateFilterTests(SearchTestBase):
+    def test_date_filters(self):
+        cases = (
+            ("released_after()", self.s.query().released_after("2020-01-01")[1, 10]),
+            ("released_before()", self.s.query().released_before("2000-01-01")[1, 10]),
+        )
+        for name, query in cases:
+            with self.subTest(name=name):
+                self._run(query)
+
+
+class GinFilterTests(SearchTestBase):
+    def test_gin_filters(self):
+        cases = (
+            ("lang()", self.s.query().lang(Language.DE)[1, 10]),
+            ("locc()", self.s.query().locc(LoCCMainClass.P)[1, 10]),
+            ("contributor_role()", self.s.query().contributor_role("Illustrator")[1, 10]),
+            ("file_type() EPUB", self.s.query().file_type(FileType.EPUB)[1, 10]),
+            ("file_type() PDF", self.s.query().file_type(FileType.PDF)[1, 10]),
+            ("file_type() TXT", self.s.query().file_type(FileType.TXT)[1, 10]),
+            (
+                "file_type() KINDLE",
+                self.s.query().search("Computers").file_type(FileType.KINDLE)[1, 10],
+            ),
+            ("author_id()", self.s.query().author_id(53)[1, 10]),
+            ("subject_id()", self.s.query().subject_id(1)[1, 10]),
+            ("bookshelf_id()", self.s.query().bookshelf_id(68)[1, 10]),
+            ("author_died_after()", self.s.query().author_died_after(1950)[1, 10]),
+            ("author_died_before()", self.s.query().author_died_before(1800)[1, 10]),
+        )
+        for name, query in cases:
+            with self.subTest(name=name):
+                self._run(query)
+
+
+class ChainedSearchTests(SearchTestBase):
+    def test_chained_searches(self):
+        cases = (
+            (
+                "FTS AUTHOR + FTS SUBJECT",
+                self.s.query().search("Shakespeare").search("Tragedy")[1, 10],
+            ),
+            (
+                "FTS TITLE + FTS BOOKSHELF",
+                self.s.query().search("Adventure").search("Children")[1, 10],
+            ),
+            (
+                "FUZZY AUTHOR + FTS TITLE",
+                self.s.query()
+                .search("Shakspeare", search_type=SearchType.FUZZY)
+                .search("Hamlet")[1, 10],
+            ),
+        )
+        for name, query in cases:
+            with self.subTest(name=name):
+                self._run(query)
+
+
+class CustomSqlTests(SearchTestBase):
+    def test_custom_sql(self):
+        cases = (
+            (
+                "where() - multi-author",
+                self.s.query().where(
+                    "COALESCE(array_length(creator_ids, 1), 0) > :n", n=2
+                )[1, 10],
+            ),
+            (
+                "where() - has credits",
+                self.s.query().where("COALESCE(array_length(credits, 1), 0) > 0")[1, 10],
+            ),
+        )
+        for name, query in cases:
+            with self.subTest(name=name):
+                self._run(query)
+
+
+class OrderingTests(SearchTestBase):
+    def test_ordering(self):
+        cases = (
+            (
+                "order_by(DOWNLOADS)",
+                self.s.query().search("Novel").order_by(OrderBy.DOWNLOADS)[1, 10],
+            ),
+            ("order_by(TITLE)", self.s.query().search("Novel").order_by(OrderBy.TITLE)[1, 10]),
+            (
+                "order_by(AUTHOR)",
+                self.s.query().search("Novel").order_by(OrderBy.AUTHOR)[1, 10],
+            ),
+            (
+                "order_by(RELEVANCE)",
+                self.s.query().search("Novel").order_by(OrderBy.RELEVANCE)[1, 10],
+            ),
+            (
+                "order_by(RELEASE_DATE)",
+                self.s.query().search("Novel").order_by(OrderBy.RELEASE_DATE)[1, 10],
+            ),
+            (
+                "order_by(RANDOM)",
+                self.s.query().search("Novel").order_by(OrderBy.RANDOM)[1, 10],
+            ),
+        )
+        for name, query in cases:
+            with self.subTest(name=name):
+                self._run(query)
+
+
+class CombinedFilterTests(SearchTestBase):
+    def test_combined_filters(self):
+        cases = (
+            (
+                "FTS + lang + public_domain",
+                self.s.query().search("Adventure").lang(Language.EN).public_domain()[1, 10],
+            ),
+            (
+                "FTS + file_type",
+                self.s.query().search("Novel").file_type(FileType.EPUB)[1, 10],
+            ),
+            (
+                "FUZZY TITLE + downloads_gte",
+                self.s.query()
+                .search("Shakspeare", search_type=SearchType.FUZZY)
+                .downloads_gte(1000)[1, 10],
+            ),
+            (
+                "author_id + file_type",
+                self.s.query().author_id(53).file_type(FileType.TXT)[1, 10],
+            ),
+            (
+                "FTS BOOKSHELF + lang",
+                self.s.query().search("Mystery").lang(Language.EN)[1, 10],
+            ),
+            (
+                "locc + public_domain",
+                self.s.query().locc(LoCCMainClass.P).public_domain()[1, 10],
+            ),
+        )
+        for name, query in cases:
+            with self.subTest(name=name):
+                self._run(query)
+
+
+_KNOWN_ETEXT = 1342
+_OPDS_ACQ = "http://opds-spec.org/acquisition/open-access"
+
+
+class CrosswalkTests(SearchTestBase):
+    def _etest(self, crosswalk):
+        data = self.s.execute(self.s.query(crosswalk).etext(_KNOWN_ETEXT)[1, 1])
+        self.assertEqual(data["total"], 1, data)
+        return data["results"][0]
+
+    def _author(self, metadata):
+        author = metadata["author"]
+        return author if isinstance(author, dict) else author[0]
+
+    def test_crosswalk_pg(self):
+        first = self._etest(Crosswalk.PG)
+        self.assertEqual(first["ebook_no"], _KNOWN_ETEXT)
+        self.assertTrue(first["title"])
+        c = first["contributors"][0]
+        for key in ("id", "name", "role", "born_floor", "died_floor"):
+            self.assertIn(key, c)
+        lang = first["language"][0]
+        self.assertIn("code", lang)
+        self.assertIn("name", lang)
+        f = first["files"][0]
+        for key in ("filename", "type", "size"):
+            self.assertIn(key, f)
+        for key in (
+            "subjects",
+            "bookshelves",
+            "release_date",
+            "downloads_last_30_days",
+            "cover_url",
+            "format",
+        ):
+            self.assertIn(key, first)
+        fmt = first["format"]
+        self.assertTrue(callable(fmt) and fmt(all=True, pretty=True))
+
+    def test_crosswalk_opds(self):
+        pub = self._etest(Crosswalk.OPDS)
+        md, links = pub["metadata"], pub["links"]
+        self.assertEqual(md["@type"], "http://schema.org/Book")
+        self.assertEqual(md["identifier"], f"https://www.gutenberg.org/ebooks/{_KNOWN_ETEXT}")
+        self.assertTrue(md["title"])
+        self.assertTrue(md["language"])
+        for key in ("accessibility", "description", "subject", "published"):
+            self.assertIn(key, md)
+        self.assertIn("links", self._author(md))
+        self.assertEqual(links[0], {
+            "rel": "self",
+            "href": f"/opds/publications?id={_KNOWN_ETEXT}",
+            "type": "application/opds-publication+json",
+        })
+        self.assertTrue(any(l.get("rel") == _OPDS_ACQ for l in links))
+        self.assertTrue(any("/opds/also?" in l.get("href", "") for l in links))
+        self.assertEqual(len(pub["images"]), 2)
+
+    def test_crosswalk_opds_small(self):
+        pub = self._etest(Crosswalk.OPDS_SMALL)
+        md, links = pub["metadata"], pub["links"]
+        self.assertEqual(md["@type"], "http://schema.org/Book")
+        self.assertEqual(md["identifier"], f"https://www.gutenberg.org/ebooks/{_KNOWN_ETEXT}")
+        self.assertTrue(md["title"])
+        self.assertTrue(md["language"])
+        author = self._author(md)
+        self.assertIn("name", author)
+        self.assertIn("sortAs", author)
+        for key in ("description", "accessibility", "published", "subject"):
+            self.assertNotIn(key, md)
+        self.assertNotIn("identifier", author)
+        self.assertNotIn("links", author)
+        self.assertEqual(links[0], {
+            "rel": "self",
+            "href": f"/opds/publications?id={_KNOWN_ETEXT}",
+            "type": "application/opds-publication+json",
+        })
+        self.assertTrue(any(l.get("rel") == _OPDS_ACQ for l in links))
+        self.assertFalse(any("/opds/also?" in l.get("href", "") for l in links))
+        self.assertEqual(len(pub["images"]), 2)
+
+
+class OpdsContributorTests(unittest.TestCase):
+    def _metadata_for(self, *creators, with_search_link=False):
+        publication_metadata = {}
+        _set_publication_contributors(
+            publication_metadata, list(creators), with_search_link=with_search_link
+        )
+        return publication_metadata
+
+    def test_author_and_introduction_contributor(self):
+        metadata = self._metadata_for(
+            {"id": 68, "name": "Austen, Jane", "role": "Author"},
+            {"id": 77, "name": "Someone Else", "role": "Author of introduction, etc."},
+        )
+        self.assertEqual(metadata["author"]["name"], "Austen, Jane")
+        self.assertEqual(metadata["contributor"]["name"], "Someone Else")
+
+    def test_translator_only_no_author_field(self):
+        metadata = self._metadata_for(
+            {"id": 55321, "name": "Renouf, P. Le Page", "role": "Translator"},
+            {"id": 55322, "name": "Naville, Edouard", "role": "Translator"},
+            with_search_link=True,
+        )
+        self.assertNotIn("author", metadata)
+        self.assertEqual(len(metadata["translator"]), 2)
+        self.assertIn("identifier", metadata["translator"][0])
+        self.assertIn("links", metadata["translator"][0])
+
+    def test_narrator_maps_to_contributor(self):
+        metadata = self._metadata_for(
+            {"id": 1, "name": "Doe, Jane", "role": "Narrator"},
+        )
+        self.assertNotIn("author", metadata)
+        self.assertEqual(metadata["contributor"]["name"], "Doe, Jane")
+
+    def test_collaborator_maps_to_contributor(self):
+        metadata = self._metadata_for(
+            {"id": 1, "name": "Smith, John", "role": "Collaborator"},
+        )
+        self.assertNotIn("author", metadata)
+        self.assertEqual(metadata["contributor"]["name"], "Smith, John")
+
+    def test_no_creators_omits_author(self):
+        self.assertNotIn("author", self._metadata_for())
+
+
+class PaginationTests(SearchTestBase):
+    def test_pagination(self):
+        cases = (
+            ("page 1", self.s.query().search("Novel")[1, 5]),
+            ("page 2", self.s.query().search("Novel")[2, 5]),
+            ("page 3", self.s.query().search("Novel")[3, 5]),
+        )
+        pages = []
+        for name, query in cases:
+            with self.subTest(name=name):
+                data = self._run(query)
+                pages.append({row.get("title") for row in data["results"]})
+        self.assertTrue(pages[0])
+        self.assertTrue(pages[1])
+        self.assertTrue(pages[2])
+        self.assertNotEqual(pages[0], pages[1])
+        self.assertNotEqual(pages[1], pages[2])
+
+
+class CountTests(SearchTestBase):
+    def test_count(self):
+        count = self.s.count(self.s.query().search("Shakespeare"))
+        self.assertGreater(count, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test.conf
+++ b/test.conf
@@ -16,3 +16,6 @@ msdrive_client_id: 'dummy'
 # for dev installs 
 thumb_base_path:  'https://dev.gutenberg.org'
 
+# For opds feed testing
+document_root: 'http://127.0.0.1:8080'
+file_host: 'www.gutenberg.org'

--- a/test.conf
+++ b/test.conf
@@ -17,5 +17,5 @@ msdrive_client_id: 'dummy'
 thumb_base_path:  'https://dev.gutenberg.org'
 
 # For opds feed testing
-document_root: 'http://127.0.0.1:8080'
+host: 'http://127.0.0.1:8000'
 file_host: 'www.gutenberg.org'

--- a/test_opds.py
+++ b/test_opds.py
@@ -1,0 +1,237 @@
+"""
+test_opds.py — HTTP load test for the OPDS 2 feed.
+
+Starts an in-process CherryPy server with production pool/thread limits,
+warms routes, then runs REQUESTS_PER_ROUTE GETs per route at CLIENT_CONCURRENCY
+(defaults: 100/20, matching CherryPy.conf).
+
+LOAD_MODE:
+  mixed      — all routes interleaved in one concurrent run
+  per_route  — one route at a time
+
+Run: python3 test_opds.py [mixed|per_route]
+"""
+
+import os
+import socket
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import contextmanager
+
+import cherrypy
+import requests
+from cherrypy.process import plugins
+from libgutenberg import GutenbergDatabase
+
+import ConnectionPool  # noqa: F401  registers plugins.ConnectionPool
+from OPDS2 import OPDSFeed, OPDS_MOUNT_CONFIG
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+TEST_CONF = os.path.join(ROOT, "test.conf")
+
+# CherryPy.conf production server/DB pool limits.
+PROD_THREAD_POOL = 20
+PROD_POOL_SIZE = 20
+PROD_MAX_OVERFLOW = 0
+PROD_POOL_TIMEOUT = 3
+
+REQUESTS_PER_ROUTE = 100
+CLIENT_CONCURRENCY = 20
+WARMUP_REQUESTS = 5
+LOAD_MODE = "mixed"  # mixed | per_route
+
+SERVER_TUNING = {
+    "server.thread_pool": PROD_THREAD_POOL,
+    "server.thread_pool_max": PROD_THREAD_POOL,
+    "server.socket_queue_size": 10,
+    "sqlalchemy.pool_size": PROD_POOL_SIZE,
+    "sqlalchemy.max_overflow": PROD_MAX_OVERFLOW,
+    "sqlalchemy.timeout": PROD_POOL_TIMEOUT,
+    "sqlalchemy.recycle": 3600,
+}
+
+LOAD_ROUTES = (
+    ("/opds/", "index"),
+    ("/opds/search?query=Shakespeare", "search"),
+    ("/opds/search?query=Shakespeare&page=2", "search page 2"),
+    ("/opds/publications?id=1342", "publication"),
+    ("/opds/also?id=1342", "also downloaded"),
+    ("/opds/bookshelves", "bookshelves index"),
+    ("/opds/bookshelves?category=LITERATURE", "bookshelf category nav"),
+    ("/opds/bookshelf_groups?category=LITERATURE", "bookshelf category groups"),
+    ("/opds/bookshelves?id=68", "bookshelf id"),
+    ("/opds/subjects?id=1", "subject browse"),
+    ("/opds/loccs?parent=P", "locc nav P"),
+    ("/opds/loccs?parent=PN", "locc leaf PN"),
+    ("/opds/loccs", "loccs index"),
+)
+
+
+def get_ephemeral_port(host="127.0.0.1"):
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((host, 0))
+        return sock.getsockname()[1]
+
+
+@contextmanager
+def opds_test_server(host="127.0.0.1"):
+    cherrypy.config.update(TEST_CONF)
+    cherrypy.config.update(SERVER_TUNING)
+    port = get_ephemeral_port(host)
+    cherrypy.config.update(
+        {
+            "server.socket_host": host,
+            "server.socket_port": port,
+            "engine.autoreload.on": False,
+            "engine.SOCKET_TIMEOUT": 60,
+            "log.screen": False,
+        }
+    )
+    GutenbergDatabase.options.update(cherrypy.config)
+    cherrypy.engine.pool = plugins.ConnectionPool(
+        cherrypy.engine,
+        params=GutenbergDatabase.get_connection_params(cherrypy.config),
+    )
+    cherrypy.engine.pool.subscribe()
+    cherrypy.tree.mount(OPDSFeed(), "/opds", OPDS_MOUNT_CONFIG)
+    cherrypy.engine.start()
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        cherrypy.engine.exit()
+
+
+def http_get(base_url, path, timeout=60):
+    return requests.get(f"{base_url}{path}", timeout=timeout)
+
+
+def warmup_routes(base_url, routes):
+    for path, _label in routes:
+        for _ in range(WARMUP_REQUESTS):
+            response = http_get(base_url, path)
+            if response.status_code != 200:
+                raise RuntimeError(f"Warmup failed for {path}: HTTP {response.status_code}")
+
+
+def percentile_ms(samples, p):
+    ordered = sorted(samples)
+    idx = max(0, min(len(ordered) - 1, int(len(ordered) * p) - 1))
+    return ordered[idx]
+
+
+def summarize(samples, error_count, request_count, elapsed_s):
+    count = len(samples)
+    rps = count / elapsed_s if elapsed_s > 0 else 0.0
+    err_pct = 100.0 * error_count / request_count if request_count else 0.0
+    p50_ms = percentile_ms(samples, 0.50) if samples else 0.0
+    p95_ms = percentile_ms(samples, 0.95) if samples else 0.0
+    p99_ms = percentile_ms(samples, 0.99) if samples else 0.0
+    status = "OK" if error_count == 0 else "ERR"
+    return count, err_pct, rps, p50_ms, p95_ms, p99_ms, status
+
+
+def execute_load(base_url, jobs, client_concurrency):
+    samples_by_label = {}
+    errors_by_label = {}
+
+    def one_request(path, label):
+        try:
+            start = time.perf_counter()
+            response = http_get(base_url, path)
+            if response.status_code != 200:
+                raise RuntimeError(f"HTTP {response.status_code}")
+            return label, (time.perf_counter() - start) * 1000, None
+        except Exception as exc:
+            return label, None, str(exc)
+
+    batch_start = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=client_concurrency) as pool:
+        futures = [pool.submit(one_request, path, label) for path, label in jobs]
+        for future in as_completed(futures):
+            label, ms, err = future.result()
+            if err:
+                errors_by_label.setdefault(label, []).append(err)
+            else:
+                samples_by_label.setdefault(label, []).append(ms)
+    elapsed_s = time.perf_counter() - batch_start
+    return samples_by_label, errors_by_label, elapsed_s
+
+
+def interleaved_jobs(routes, requests_per_route):
+    n = len(routes)
+    return [routes[i % n] for i in range(n * requests_per_route)]
+
+
+def print_report(title, labels, samples_by_label, errors_by_label, elapsed_s, per_route_count, total_jobs=None, elapsed_by_label=None):
+    width = 105
+    job_count = total_jobs or per_route_count * len(labels)
+    print("=" * width)
+    print(f"OPDS load test — {title} ({job_count} requests, concurrency {CLIENT_CONCURRENCY})")
+    print("=" * width)
+    print(
+        f"{'Route':<22} | {'Reqs':>5} | {'Err%':>5} | {'RPS':>6} | "
+        f"{'P50 ms':>7} | {'P95 ms':>7} | {'P99 ms':>7} | Status"
+    )
+    print("=" * width)
+    all_samples, total_errors = [], 0
+    for label in labels:
+        samples = samples_by_label.get(label, [])
+        errors = errors_by_label.get(label, [])
+        total_errors += len(errors)
+        all_samples.extend(samples)
+        route_elapsed = (elapsed_by_label or {}).get(label, elapsed_s)
+        stats = summarize(samples, len(errors), per_route_count, route_elapsed)
+        count, err_pct, rps, p50, p95, p99, status = stats
+        print(
+            f"{label:<22} | {count:>5} | {err_pct:>5.1f} | {rps:>6.1f} | "
+            f"{p50:>7.1f} | {p95:>7.1f} | {p99:>7.1f} | {status}"
+        )
+    if total_jobs:
+        stats = summarize(all_samples, total_errors, total_jobs, elapsed_s)
+        count, err_pct, rps, p50, p95, p99, status = stats
+        print("-" * width)
+        print(
+            f"{'TOTAL':<22} | {count:>5} | {err_pct:>5.1f} | {rps:>6.1f} | "
+            f"{p50:>7.1f} | {p95:>7.1f} | {p99:>7.1f} | {status}"
+        )
+    print("=" * width)
+
+
+def run_mixed(base_url):
+    warmup_routes(base_url, LOAD_ROUTES)
+    jobs = interleaved_jobs(LOAD_ROUTES, REQUESTS_PER_ROUTE)
+    samples, errors, elapsed = execute_load(base_url, jobs, CLIENT_CONCURRENCY)
+    labels = [label for _path, label in LOAD_ROUTES]
+    print_report("mixed load", labels, samples, errors, elapsed, REQUESTS_PER_ROUTE, len(jobs))
+
+
+def run_per_route(base_url):
+    labels, samples, errors, elapsed_by_label = [], {}, {}, {}
+    for path, label in LOAD_ROUTES:
+        warmup_routes(base_url, ((path, label),))
+        route_samples, route_errors, elapsed = execute_load(
+            base_url, [(path, label)] * REQUESTS_PER_ROUTE, CLIENT_CONCURRENCY
+        )
+        labels.append(label)
+        samples[label] = route_samples.get(label, [])
+        errors[label] = route_errors.get(label, [])
+        elapsed_by_label[label] = elapsed
+    print_report(
+        "per-route load", labels, samples, errors, 0.0, REQUESTS_PER_ROUTE,
+        elapsed_by_label=elapsed_by_label,
+    )
+
+
+def run_load(mode=LOAD_MODE):
+    if mode not in ("mixed", "per_route"):
+        raise SystemExit(f"Unknown LOAD_MODE {mode!r}; use mixed or per_route")
+    with opds_test_server() as base_url:
+        if mode == "mixed":
+            run_mixed(base_url)
+        else:
+            run_per_route(base_url)
+
+
+if __name__ == "__main__":
+    run_load(sys.argv[1] if len(sys.argv) > 1 else LOAD_MODE)

--- a/test_opds.py
+++ b/test_opds.py
@@ -94,7 +94,7 @@ def opds_test_server(host="127.0.0.1"):
         params=GutenbergDatabase.get_connection_params(cherrypy.config),
     )
     cherrypy.engine.pool.subscribe()
-    cherrypy.tree.mount(OPDSFeed(), "/opds", OPDS_MOUNT_CONFIG)
+    cherrypy.tree.mount(OPDSFeed(), "/opds", {"/": OPDS_MOUNT_CONFIG["/opds"]})
     cherrypy.engine.start()
     try:
         yield f"http://{host}:{port}"


### PR DESCRIPTION
## Summary
Adds an OPDS 2.0 catalog at `/opds`, backed by the `mv_books_dc` materialized view. This version has been approved by the designers of the OPDS standards and is functionally complete.

`OPDS2.py` is the CherryPy feed handler. It defines the routes, and JSON output. `CherryPyApp.py` mounts it at `/opds`.

`mv_search/` is a new Python module that queries `mv_books_dc` in PostgreSQL. It handles search, facet filtering, and sorting. `OPDS2.py` calls into it and formats the results as OPDS JSON.

For ops, autocat3 needs [`mv_books_dc`](https://github.com/gutenbergtools/pgdb/pull/15) present and refreshed. `Timer.py` calls `refresh_mv_books_dc()` on a daily schedule (`mv_refresh_hour` in `CherryPy.conf`, default 17). The DB user in `pguser` needs execute on that function and access to the view.

## Tests

- `mv_search/test_search.py` tests against a live DB (search, facets, crosswalks, contributor mapping). Run: `python3 -m unittest mv_search.test_search -v`
- `test_opds.py` HTTP load test for `/opds` routes. Run: `python3 test_opds.py [mixed|per_route]`
  - **mixed** (default) tests all routes in one run; simulates concurrent real-world traffic
  - **per_route** hammers one route at a time; easier to isolate slow or failing endpoints
- For local dev, run python3 OPDS2.py directly. It starts a CherryPy server on port 8080 using test.conf and serves the feed at http://localhost:8080/opds/