### PR TITLE
Adding Ebook Counter to Homepage

### DIFF
--- a/CherryPyApp.py
+++ b/CherryPyApp.py
@@ -39,6 +39,7 @@ from SearchPage import BookSearchPage, AuthorSearchPage, SubjectSearchPage, Book
 from BibrecPage import BibrecPage
 from AdvSearchPage import AdvSearchPage
 import CoverPages
+import EbookCount
 import QRCodePage
 import MetricsPage
 import Sitemap
@@ -259,6 +260,9 @@ def main():
 
     d.connect('cover', r'/covers/{size:small|medium}/{order:latest|popular|random}/{count}',
                controller=CoverPages.CoverPages())
+
+    d.connect('ebook_count', r'/ebook_count/',
+               controller=EbookCount.EbookCount())
 
     d.connect('qrcode', r'/qrcode/',
                controller=QRCodePage.QRCodePage())

--- a/EbookCount.py
+++ b/EbookCount.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: utf-8 -*-
+
+"""
+EbookCount.py
+
+Copyright 2026 by Project Gutenberg
+
+Distributable under the GNU General Public License Version 3 or newer.
+
+Serve the exact ebook count as plain text for the homepage slogan.
+
+"""
+
+from __future__ import unicode_literals
+
+import cherrypy
+
+import BaseSearcher
+
+
+class EbookCount(object):
+    """ Serve the current ebook count as plain text. """
+
+    def index(self, **dummy_kwargs):
+        """ Return the cached ebook count, comma-grouped. """
+        cherrypy.response.headers['Content-Type'] = 'text/plain; charset=utf-8'
+        return format(BaseSearcher.books_in_archive, ',d').encode('utf-8')

--- a/testlinks.html
+++ b/testlinks.html
@@ -27,3 +27,5 @@ test links</h1>
 <a href="http://127.0.0.1:8000/ebooks.opds/">OPDS start page</a>
 <br>
 <a href="http://127.0.0.1:8000/ebooks/sitemaps/0">sitemap</a>
+<br>
+<a href="http://127.0.0.1:8000/ebook_count/">ebook count</a>


### PR DESCRIPTION
Adds `/ebook_count/` endpoint to serve the ebook count as plain text reusing the number autocat3 already caches. Sister PR for:  https://github.com/gutenbergtools/gutenbergsite/pull/314