### PR TITLE
Open engine in autocommit mode

### DIFF
--- a/ConnectionPool.py
+++ b/ConnectionPool.py
@@ -65,7 +65,7 @@ class ConnectionPool(plugins.SimplePlugin):
                                    max_overflow=max_overflow,
                                    timeout=timeout,
                                    recycle=recycle)
-        engine = create_engine(DUMMY_SQL_URL, echo=False, pool=self.pool)
+        engine = create_engine(DUMMY_SQL_URL, echo=False, pool=self.pool, isolation_level="AUTOCOMMIT")
         Session = sessionmaker(bind=engine)
         return engine, Session
 


### PR DESCRIPTION
This remove the automatic transaction that is created for selects thereby reducing lock contention on the database.

This is currently running at https://dev.gutenberg.org.