### PR TITLE
Use gunicorn to run autocat3 for improved scalability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ venv.bak/
 # for devmode
 gutenberg/
 pics/
+
+# local gunicorn config
+local_gunicorn.py

--- a/CherryPy.conf
+++ b/CherryPy.conf
@@ -7,14 +7,6 @@ environment: 'production'
 # if >= 12 (kf8, epub3) are not hidden. 
 version: 12
 
-pidfile:  '/var/run/autocat/autocat3.pid'
-
-server.socket_host: '::'
-server.socket_port: 8000
-server.socket_queue_size: 10
-server.thread_pool: 20
-server.thread_pool_max: 20
-
 # change host and postgres params in .autocat3 or /etc/autocat3.conf files
 pghost:     'localhost'
 pgport:     5432
@@ -25,7 +17,7 @@ host:        'www.gutenberg.org'
 host_https:  1
 file_host:   'www.gutenberg.org'
 
-
+# with gunicorn these values are *per-thread* not per-process
 sqlalchemy.pool_size: 20
 sqlalchemy.max_overflow: 0
 sqlalchemy.timeout: 3
@@ -45,16 +37,34 @@ log.screen: False
 log.error_file:  ''
 log.access_file: ''
 
-logger.error_file:  '/var/lib/autocat/log/error.log'
-logger.access_file: '/var/lib/autocat/log/access.log'
-log.rot_max_bytes: 104857600
-log.rot_backup_count: 2
 tools.log_headers.on: False
 tools.log_tracebacks.on: True
 
 document_root:    'https://www.gutenberg.org'
 # use this if book covers are served at a separate base url, (often useful for dev environments)
 thumb_base_path: ''
+
+# ----------------------------------------------------------------------------
+# CherryPy HTTP server settings
+#
+# These settings are only used by the CherryPy HTTP server. They are not
+# used if running with gunicorn. See gunicorn.conf.py for those.
+
+pidfile:  '/var/run/autocat/autocat3.pid'
+
+server.socket_host: '::'
+server.socket_port: 8000
+server.socket_queue_size: 10
+server.thread_pool: 20
+server.thread_pool_max: 20
+
+logger.error_file:  '/var/lib/autocat/log/error.log'
+logger.access_file: '/var/lib/autocat/log/access.log'
+log.rot_max_bytes: 104857600
+log.rot_backup_count: 2
+
+# ----------------------------------------------------------------------------
+
 
 [/]
 tools.proxy.on: True

--- a/CherryPyApp.py
+++ b/CherryPyApp.py
@@ -19,8 +19,6 @@ from __future__ import unicode_literals
 import logging
 import logging.handlers # rotating file handler
 import os
-import time
-import traceback
 
 import cherrypy
 from cherrypy.process import plugins
@@ -78,126 +76,10 @@ class MyRoutesDispatcher(cherrypy.dispatch.RoutesDispatcher):
         cherrypy.dispatch.RoutesDispatcher.connect(self, name, route, controller, **kwargs)
 
 
-def main():
-    """ Main function. """
-
-    # default config
-    cherrypy.config.update({
-        'uid': 0,
-        'gid': 0,
-        'server_name': 'localhost',
-        'genshi.template_dir': os.path.join(install_dir, 'templates'),
-        'daemonize': False,
-        'pidfile': None,
-        'host': 'localhost',
-        'file_host': 'localhost',
-        'devmode': False,
-        })
-
-    cherrypy.config.update(CHERRYPY_CONFIG)
-    extra_config = ''
-    for config_filename in LOCAL_CONFIG:
-        try:
-            cherrypy.config.update(config_filename)
-            extra_config = config_filename
-            break
-        except IOError:
-            pass
-
-    # Rotating Logs
-    # CherryPy will already open log files if present in config
-    error_file = access_file = ''
-    # read the logger file locations from config file.
-    if not cherrypy.log.error_file:
-        error_file = cherrypy.config.get('logger.error_file', '')
-    if not cherrypy.log.access_file:
-        access_file = cherrypy.config.get('logger.access_file', '')
-
-    # disable log file handlers
-    cherrypy.log.error_file = ""
-    cherrypy.log.access_file = ""
-
-    # set up python logging
-    max_bytes = getattr(cherrypy.log, "rot_max_bytes", 100 * 1024 * 1024)
-    backup_count = getattr(cherrypy.log, "rot_backup_count", 2)
-
-    if error_file:
-        h = logging.handlers.RotatingFileHandler(error_file, 'a', max_bytes, backup_count, 'utf-8')
-        h.setLevel(logging.WARNING)
-        h.setFormatter(cherrypy._cplogging.logfmt)
-        cherrypy.log.error_log.addHandler(h)
-
-    if access_file:
-        h = logging.handlers.RotatingFileHandler(access_file, 'a', max_bytes, backup_count, 'utf-8')
-        h.setLevel(logging.INFO)
-        h.setFormatter(cherrypy._cplogging.logfmt)
-        cherrypy.log.access_log.addHandler(h)
-
-
-
-    if not cherrypy.config['daemonize']:
-        ch = logging.StreamHandler()
-        ch.setLevel(logging.DEBUG)
-        ch.setFormatter(cherrypy._cplogging.logfmt)
-        cherrypy.log.error_log.addHandler(ch)
-
-    # continue app init
-    #
-
-    cherrypy.log('*' * 80, context='ENGINE', severity=logging.INFO)
-    cherrypy.log("Using config file '%s'." % CHERRYPY_CONFIG,
-                  context='ENGINE', severity=logging.INFO)
-    if extra_config:
-        cherrypy.log('extra_config: %s' % extra_config, context='ENGINE', severity=logging.INFO)
-
-    # after cherrypy.config is parsed
-    Formatters.init()
-    cherrypy.log("Continuing App Init", context='ENGINE', severity=logging.INFO)
-
-    cherrypy.log("Continuing App Init", context='ENGINE', severity=logging.INFO)
-    cherrypy.tools.I18nTool = i18n_tool.I18nTool()
-
-    cherrypy.log("Continuing App Init", context='ENGINE', severity=logging.INFO)
-
-
-    cherrypy.config['all_hosts'] = (
-        cherrypy.config['host'], cherrypy.config['file_host'])
-    
-    cherrypy.config.update({'error_page.404': error_page_404})
-
-    if hasattr(cherrypy.engine, 'signal_handler'):
-        cherrypy.engine.signal_handler.subscribe()
-
-    GutenbergDatabase.options.update(cherrypy.config)
-    cherrypy.engine.pool = plugins.ConnectionPool(
-        cherrypy.engine, params=GutenbergDatabase.get_connection_params(cherrypy.config))
-    cherrypy.engine.pool.subscribe()
-
-    plugins.Timer(cherrypy.engine).subscribe()
-
-    cherrypy.log("Daemonizing", context='ENGINE', severity=logging.INFO)
-
-    if cherrypy.config['daemonize']:
-        plugins.Daemonizer(cherrypy.engine).subscribe()
-
-    uid = cherrypy.config['uid']
-    gid = cherrypy.config['gid']
-    if uid > 0 or gid > 0:
-        plugins.DropPrivileges(cherrypy.engine, uid=uid, gid=gid, umask=0o22).subscribe()
-
-    if cherrypy.config['pidfile']:
-        pid = plugins.PIDFile(cherrypy.engine, cherrypy.config['pidfile'])
-        # Write pidfile after privileges are dropped(prio == 77)
-        # or we will not be able to remove it.
-        cherrypy.engine.subscribe('start', pid.start, 78)
-        cherrypy.engine.subscribe('exit', pid.exit, 78)
-
-
+def get_app():
     cherrypy.log("Setting up routes", context='ENGINE', severity=logging.INFO)
 
     # setup 'routes' dispatcher
-    #
-    # d = cherrypy.dispatch.RoutesDispatcher(full_result=True)
     d = MyRoutesDispatcher(full_result=True)
     cherrypy.routes_mapper = d.mapper
 
@@ -323,9 +205,6 @@ def main():
         d.connect('msdrive_callback', r'/ebooks/send/msdrive/',
                    controller=msdrive)
 
-    # start http server
-    #
-
     cherrypy.log("Mounting root", context='ENGINE', severity=logging.INFO)
 
     app = cherrypy.tree.mount(root=None, config=CHERRYPY_CONFIG)
@@ -337,6 +216,134 @@ def main():
                                   'tools.staticdir.dir': install_dir + "/gutenberg"}})
         app.merge({'/pics': {'tools.staticdir.on': True,
                              'tools.staticdir.dir': install_dir + "/pics"}})
+
+    return app
+
+
+def configure():
+    # default config
+    cherrypy.config.update({
+        'server_name': 'localhost',
+        'genshi.template_dir': os.path.join(install_dir, 'templates'),
+        'host': 'localhost',
+        'file_host': 'localhost',
+        'devmode': False,
+        })
+
+    cherrypy.config.update(CHERRYPY_CONFIG)
+    extra_config = ''
+    for config_filename in LOCAL_CONFIG:
+        try:
+            cherrypy.config.update(config_filename)
+            extra_config = config_filename
+            break
+        except IOError:
+            pass
+
+    cherrypy.config['all_hosts'] = (
+        cherrypy.config['host'], cherrypy.config['file_host'])
+
+    cherrypy.config.update({'error_page.404': error_page_404})
+
+    cherrypy.tools.I18nTool = i18n_tool.I18nTool()
+
+    Formatters.init()
+
+    # configure database
+    GutenbergDatabase.options.update(cherrypy.config)
+    cherrypy.engine.pool = plugins.ConnectionPool(
+        cherrypy.engine, params=GutenbergDatabase.get_connection_params(cherrypy.config))
+    cherrypy.engine.pool.subscribe()
+
+    # configure timers
+    plugins.Timer(cherrypy.engine).subscribe()
+
+    return extra_config
+
+
+def main():
+    """ Main function. """
+
+    # CherryPy HTTP server config
+    cherrypy.config.update({
+        'uid': 0,
+        'gid': 0,
+        'daemonize': False,
+        'pidfile': None,
+        'devmode': False,
+        })
+
+    extra_config = configure()
+
+    # Rotating Logs
+    # CherryPy will already open log files if present in config
+    error_file = access_file = ''
+    # read the logger file locations from config file.
+    if not cherrypy.log.error_file:
+        error_file = cherrypy.config.get('logger.error_file', '')
+    if not cherrypy.log.access_file:
+        access_file = cherrypy.config.get('logger.access_file', '')
+
+    # disable log file handlers
+    cherrypy.log.error_file = ""
+    cherrypy.log.access_file = ""
+
+    # set up python logging
+    max_bytes = getattr(cherrypy.log, "rot_max_bytes", 100 * 1024 * 1024)
+    backup_count = getattr(cherrypy.log, "rot_backup_count", 2)
+
+    if error_file:
+        h = logging.handlers.RotatingFileHandler(error_file, 'a', max_bytes, backup_count, 'utf-8')
+        h.setLevel(logging.WARNING)
+        h.setFormatter(cherrypy._cplogging.logfmt)
+        cherrypy.log.error_log.addHandler(h)
+
+    if access_file:
+        h = logging.handlers.RotatingFileHandler(access_file, 'a', max_bytes, backup_count, 'utf-8')
+        h.setLevel(logging.INFO)
+        h.setFormatter(cherrypy._cplogging.logfmt)
+        cherrypy.log.access_log.addHandler(h)
+
+    if not cherrypy.config['daemonize']:
+        ch = logging.StreamHandler()
+        ch.setLevel(logging.DEBUG)
+        ch.setFormatter(cherrypy._cplogging.logfmt)
+        cherrypy.log.error_log.addHandler(ch)
+
+    # continue app init
+    #
+
+    cherrypy.log('*' * 80, context='ENGINE', severity=logging.INFO)
+    cherrypy.log("Using config file '%s'." % CHERRYPY_CONFIG,
+                  context='ENGINE', severity=logging.INFO)
+    if extra_config:
+        cherrypy.log('extra_config: %s' % extra_config, context='ENGINE', severity=logging.INFO)
+
+    # after cherrypy.config is parsed
+    if hasattr(cherrypy.engine, 'signal_handler'):
+        cherrypy.engine.signal_handler.subscribe()
+
+    # start http server
+    #
+
+    cherrypy.log("Daemonizing", context='ENGINE', severity=logging.INFO)
+
+    if cherrypy.config['daemonize']:
+        plugins.Daemonizer(cherrypy.engine).subscribe()
+
+    uid = cherrypy.config['uid']
+    gid = cherrypy.config['gid']
+    if uid > 0 or gid > 0:
+        plugins.DropPrivileges(cherrypy.engine, uid=uid, gid=gid, umask=0o22).subscribe()
+
+    if cherrypy.config['pidfile']:
+        pid = plugins.PIDFile(cherrypy.engine, cherrypy.config['pidfile'])
+        # Write pidfile after privileges are dropped(prio == 77)
+        # or we will not be able to remove it.
+        cherrypy.engine.subscribe('start', pid.start, 78)
+        cherrypy.engine.subscribe('exit', pid.exit, 78)
+
+    app = get_app()
 
     return app
 

--- a/MetricsPage.py
+++ b/MetricsPage.py
@@ -33,25 +33,28 @@ class MetricsPage (Page):
             }
 
         http_server = cherrypy.server
-        http_server_metrics = {
-            "autocat3_httpserver_socket_queue_size": http_server.socket_queue_size,
-            "autocat3_httpserver_accepted_queue_size": http_server.accepted_queue_size,
-            "autocat3_httpserver_pool_minsize": http_server.thread_pool,
-            # we include thread_pool_max even though the value is currently completely
-            # meaningless https://github.com/cherrypy/cheroot/issues/190
-            "autocat3_httpserver_pool_maxsize": http_server.thread_pool_max,
-        }
-
-        # https://docs.cherrypy.dev/en/latest/_modules/cherrypy/_cpserver.html#Server
-        # This assumes we're using the default CherryPy cheroot HTTP server
-        if (hasattr(cherrypy.server.httpserver, "requests")):
-            http_server_pool = cherrypy.server.httpserver.requests
-            http_server_metrics = http_server_metrics | {
-                "autocat3_httpserver_pool_available": http_server_pool.idle,
-                "autocat3_httpserver_pool_size": len(http_server_pool._threads),
-                "autocat3_httpserver_pool_used": len(http_server_pool._threads) - http_server_pool.idle,
-                "autocat3_httpserver_pool_queued": http_server_pool.qsize,
+        if http_server.running:
+            http_server_metrics = {
+                "autocat3_httpserver_socket_queue_size": http_server.socket_queue_size,
+                "autocat3_httpserver_accepted_queue_size": http_server.accepted_queue_size,
+                "autocat3_httpserver_pool_minsize": http_server.thread_pool,
+                # we include thread_pool_max even though the value is currently completely
+                # meaningless https://github.com/cherrypy/cheroot/issues/190
+                "autocat3_httpserver_pool_maxsize": http_server.thread_pool_max,
             }
+
+            # https://docs.cherrypy.dev/en/latest/_modules/cherrypy/_cpserver.html#Server
+            # This assumes we're using the default CherryPy cheroot HTTP server
+            if (hasattr(cherrypy.server.httpserver, "requests")):
+                http_server_pool = cherrypy.server.httpserver.requests
+                http_server_metrics = http_server_metrics | {
+                    "autocat3_httpserver_pool_available": http_server_pool.idle,
+                    "autocat3_httpserver_pool_size": len(http_server_pool._threads),
+                    "autocat3_httpserver_pool_used": len(http_server_pool._threads) - http_server_pool.idle,
+                    "autocat3_httpserver_pool_queued": http_server_pool.qsize,
+                }
+        else:
+            http_server_metrics = {}
 
         # https://github.com/sqlalchemy/sqlalchemy/blob/d5c89a541f5233baf6b6a7498746820caa7b407f/lib/sqlalchemy/pool/impl.py
         if cherrypy.engine.pool.engine:

--- a/Pipfile
+++ b/Pipfile
@@ -41,3 +41,4 @@ urllib3 = ">=2.6.3"
 idna = "*"
 lxml = "*"
 libgutenberg = "==0.11.0"
+gunicorn = {extras = ["gthread"], version = "*"}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2c1f9e5d9c5c2e2b39f0eb29bcfd0c448cd5b648fea5a6fb618c99d09a2c8212"
+            "sha256": "98e43f16deae2c49ceef29ab28b838f52f4b1457df5b23d7d60c6c557b767c21"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -269,6 +269,17 @@
             "markers": "python_version >= '3.9'",
             "version": "==3.2.5"
         },
+        "gunicorn": {
+            "extras": [
+                "gthread"
+            ],
+            "hashes": [
+                "sha256:ec400d38950de4dfd418cff8328b2c8faed0edb0d517d3394e457c317908ca4d",
+                "sha256:f014447a0101dc57e294f6c18ca6b40227a4c90e9bdb586042628030cba004ec"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==23.0.0"
+        },
         "html5lib": {
             "hashes": [
                 "sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d",
@@ -501,6 +512,14 @@
             "index": "pypi",
             "markers": "python_version >= '3.8'",
             "version": "==3.3.1"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e",
+                "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==26.2"
         },
         "pillow": {
             "hashes": [

--- a/autocat3.service
+++ b/autocat3.service
@@ -8,7 +8,7 @@ Type=simple
 RuntimeDirectory=autocat
 WorkingDirectory=/var/lib/autocat/autocat3
 ExecStartPre=-/usr/bin/mkdir -p /var/run/autocat
-ExecStart=/usr/local/bin/pipenv run python CherryPyApp.py
+ExecStart=/var/lib/autocat/autocat3/.venv/bin/gunicorn
 LimitNOFILE=infinity
 
 

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,24 @@
+import multiprocessing
+
+wsgi_app = "wsgi:app"
+bind = "0.0.0.0:8000"
+worker_class = "gthread"
+
+# total autocat workers (threads * workers) must be < maximum number of
+# postgres connections
+autocat_max_workers = 100
+workers = multiprocessing.cpu_count()
+threads = max(autocat_max_workers // workers, 1)
+
+# limit the total number of connections
+backlog = 512
+worker_connections = 1000
+
+# where to write access and error logs
+accesslog = "/var/lib/autocat/log/access.log"
+errorlog = "/var/lib/autocat/log/error.log"
+
+try:
+    from local_gunicorn import *
+except ImportError:
+    pass

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,25 @@
+# wsgi app for gunicorn
+
+import cherrypy
+
+from CherryPyApp import configure, get_app
+
+
+configure()
+
+# Disable the autoreload which won't play well
+cherrypy.config.update({'engine.autoreload.on': False})
+
+# write logs to WSGI logger
+cherrypy.log.wsgi = True
+
+# let's not start the CherryPy HTTP server
+cherrypy.server.unsubscribe()
+
+# use CherryPy's signal handling
+cherrypy.engine.signals.subscribe()
+
+# Run the engine but don't block on it
+cherrypy.engine.start()
+
+app = get_app()


### PR DESCRIPTION
Use gunicorn to run autocat3 in multiple processes & threads. This significantly improves the application's scalability and allows us to take advantage of multiple CPUs without hitting the python GIL.

On pgnew this improved the number of requests per second that the application can serve in proportion to the number of CPUs we allocate to it (so 20x), see the [spreadsheet](https://docs.google.com/spreadsheets/d/1J_E2VIXjZegaLvqe1MvxR1wfL-KJ4foqJmd5vOySjrg/edit?gid=0#gid=0).

Important notes about this change:
* The application can still be run under the CherryPy HTTP server, either in development or in production. The updated `autocat3.service` file runs it under gunicorn but this file is not automatically picked up in ibiblio: the file is copied over to systemd and the daemon reloaded. On pgnew this file is a symlink, not a copy.
* gunicorn controls logging, not CherryPy. In a multi-process model multiple processes are trying to write to the same file which doesn't work well. Moreover, each CherryPy process logger is trying to manage log rotation which is going to be a mess. This will require us to manage log rotation differently in production but the logging itself still works as-is.
* Unlike in the CherryPy single-process model, _each_ gunicorn thread is going to open a connection to the database -- and that's `workers` * `threads`. This isn't a problem, it's just an important change because the number of total threads needs to be < the maximum number of postgresql connections (100 on pgnew, 300 on ibiblio). This makes the effective sqlalchemy pool size 1.
* We lose visibility into autocat3 metrics because the `/metrics/` endpoint is per-thread and thus not useful. gunicorn provides some metrics, but the most useful come in version 25 which requires a more recent version of python than 3.9. I spent 30m on alternative approaches but haven't come up with anything yet.
* To make more effective use of this code on ibiblio, we'll want them to provision more CPUs to the autocat3 system, probably at least 4 total, ideally 8.
* We will need to pay careful attention to memory usage and maybe adjust some of the caching that autocat3 does as that is going to be per-thread where before some of it was per-process (more efficient) and some of it was per-thread.

Fixes https://github.com/gutenbergtools/autocat3/issues/247